### PR TITLE
Fix HTTPS by disabling CT enforcing.

### DIFF
--- a/resources/common/patches/patch_order
+++ b/resources/common/patches/patch_order
@@ -71,4 +71,5 @@ ungoogled-chromium/disable-windows-zone-identifier.patch
 ungoogled-chromium/fix-bundled-devtools.patch
 ungoogled-chromium/remove-get-help-button.patch
 ungoogled-chromium/fix-building-with-iridium-trknotify.patch
+ungoogled-chromium/fix-https-by-disabling-ct-enforcing.patch
 

--- a/resources/common/patches/ungoogled-chromium/fix-https-by-disabling-ct-enforcing.patch
+++ b/resources/common/patches/ungoogled-chromium/fix-https-by-disabling-ct-enforcing.patch
@@ -1,0 +1,11 @@
+--- a/net/http/transport_security_state.cc
++++ b/net/http/transport_security_state.cc
+@@ -732,7 +732,7 @@
+     const X509Certificate* validated_certificate_chain,
+     const HashValueVector& public_key_hashes) {
+   using CTRequirementLevel = RequireCTDelegate::CTRequirementLevel;
+-
++  return false;
+   CTRequirementLevel ct_required = CTRequirementLevel::DEFAULT;
+   if (require_ct_delegate_)
+     ct_required = require_ct_delegate_->IsCTRequiredForHost(hostname);


### PR DESCRIPTION
Hey,

You can use this patch to fix the HTTPS mess until you find time to switch to Chromium 54.

Cheers,
Vittorio