### PR TITLE
Fix building with Widevine support on MacOS

### DIFF
--- a/resources/macos/gn_flags
+++ b/resources/macos/gn_flags
@@ -1,3 +1,3 @@
 is_clang=true
 clang_use_chrome_plugins=false
-enable_widevine=false
+enable_widevine=true

--- a/resources/macos/patches/patch_order
+++ b/resources/macos/patches/patch_order
@@ -1,2 +1,3 @@
 ungoogled-macos/disable-symbol-order-verification.patch
 ungoogled-macos/add-trknotify-gn-dependency.patch
+ungoogled-macos/fix-widevine-macos.patch

--- a/resources/macos/patches/ungoogled-macos/fix-widevine-macos.patch
+++ b/resources/macos/patches/ungoogled-macos/fix-widevine-macos.patch
@@ -1,23 +1,23 @@
-#Fix WidevineCDM compiling on MacOS
+# Fix WidevineCDM compiling on MacOS
 
 --- a/third_party/widevine/cdm/BUILD.gn
 +++ b/third_party/widevine/cdm/BUILD.gn
-@@ -92,17 +92,7 @@
+@@ -92,16 +92,16 @@
        "//build/config/sanitizers:deps",
      ]
  
 -    if (is_mac) {
--      ldflags = [
--        # Not to strip important symbols by -Wl,-dead_strip.
--        "-Wl,-exported_symbol,_PPP_GetInterface",
--        "-Wl,-exported_symbol,_PPP_InitializeModule",
--        "-Wl,-exported_symbol,_PPP_ShutdownModule",
--      ]
--      #TODO(jrummell) Mac: 'DYLIB_INSTALL_NAME_BASE': '@loader_path',
--    } else if (is_posix && !is_mac) {
--      cflags = [ "-fvisibility=hidden" ]
--    }
-+
++    if (false) {
+       ldflags = [
+         # Not to strip important symbols by -Wl,-dead_strip.
+         "-Wl,-exported_symbol,_PPP_GetInterface",
+         "-Wl,-exported_symbol,_PPP_InitializeModule",
+         "-Wl,-exported_symbol,_PPP_ShutdownModule",
+       ]
+       #TODO(jrummell) Mac: 'DYLIB_INSTALL_NAME_BASE': '@loader_path',
+     } else if (is_posix && !is_mac) {
+       cflags = [ "-fvisibility=hidden" ]
+     }
    }
  } else {
    group("widevinecdm") {

--- a/resources/macos/patches/ungoogled-macos/fix-widevine-macos.patch
+++ b/resources/macos/patches/ungoogled-macos/fix-widevine-macos.patch
@@ -1,0 +1,23 @@
+#Fix WidevineCDM compiling on MacOS
+
+--- a/third_party/widevine/cdm/BUILD.gn
++++ b/third_party/widevine/cdm/BUILD.gn
+@@ -92,17 +92,7 @@
+       "//build/config/sanitizers:deps",
+     ]
+ 
+-    if (is_mac) {
+-      ldflags = [
+-        # Not to strip important symbols by -Wl,-dead_strip.
+-        "-Wl,-exported_symbol,_PPP_GetInterface",
+-        "-Wl,-exported_symbol,_PPP_InitializeModule",
+-        "-Wl,-exported_symbol,_PPP_ShutdownModule",
+-      ]
+-      #TODO(jrummell) Mac: 'DYLIB_INSTALL_NAME_BASE': '@loader_path',
+-    } else if (is_posix && !is_mac) {
+-      cflags = [ "-fvisibility=hidden" ]
+-    }
++
+   }
+ } else {
+   group("widevinecdm") {


### PR DESCRIPTION
Fixes building with the `enable_widevine=true` flag on OS X. Widevine still doesn't work out of the box, but the user can copy the plugin files from Google Chrome and get it to work now.