### PR TITLE
fix linux build

### DIFF
--- a/buildlib/linux.py
+++ b/buildlib/linux.py
@@ -67,7 +67,7 @@ class LinuxBuilder(QuiltPatchComponent, GNMetaBuildComponent):
                         arcname = tar_root_dir / file_path.relative_to(self._sandbox_dir /
                                                                        self.build_output)
                         yield (str(arcname), str(file_path))
-            for target_rel_path, input_rel_path in self._extra_packaging_files:
+            for target_rel_path, input_rel_path in self._extra_packaging_files.items():
                 target_path = self._sandbox_dir / self.build_output / target_rel_path
                 input_path = self._resources / input_rel_path
                 target_path.write_bytes(input_path.read_bytes())


### PR DESCRIPTION
I'm not a python expert, but I got an error when trying to build on linux. This fixed it.

```
Traceback (most recent call last):
  File "./build.py", line 58, in <module>
    exit(main())
  File "./build.py", line 44, in main
    builder.generate_package()
  File "/ungoogled-chromium/buildlib/linux.py", line 75, in generate_package
    for arcname, real_path in file_list_generator():
  File "/ungoogled-chromium/buildlib/linux.py", line 70, in file_list_generator
    for target_rel_path, input_rel_path in self._extra_packaging_files:
ValueError: too many values to unpack (expected 2)
```