### PR TITLE
Add note to macOS widevine FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -109,6 +109,8 @@ This applies to version `55.0.2883.95`. In case you're using a different version
 
 `cp -R Google\ Chrome.app/Contents/Versions/55.0.2883.95/Google\ Chrome\ Framework.framework/Libraries/WidevineCdm Chromium.app/Contents/Versions/55.0.2883.95/Chromium\ Framework.framework/Libraries/`
 
+Note that there is no slash after `WidevineCdm`.
+
 ## How do I get the Namespace Sandbox to work on Linux?
 
 Enable the kernel option `unprivileged_userns_clone`


### PR DESCRIPTION
Note that there is no slash following the first path in the copy command. If a slash is included - which many shell autocompletions will do automatically - then the command will copy only the contents of the directory instead of the directory itself.

I made this mistake once; this note might save somebody 10 minutes of wondering.