### PR TITLE
Resolved fuzz in minimal.patch

### DIFF
--- a/resources/packaging/debian/minimal.patch
+++ b/resources/packaging/debian/minimal.patch
@@ -65,7 +65,7 @@
   libharfbuzz-dev,
 --- a/rules.in
 +++ b/rules.in
-@@ -42,10 +42,6 @@ ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
+@@ -42,12 +42,8 @@
  njobs=-j$(patsubst parallel=%,%,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
  endif
  
@@ -74,9 +74,11 @@
 -          /usr/share/javascript/jquery-flot/*min.js \
 -
  %:
-- 	dh $@
+-	dh $@
 +	dh $@ --parallel
  
+ $ungoog{build_output}/gn:
+ 	mkdir -p $ungoog{build_output} || true
 @@ -56,13 +52,6 @@ $ungoog{build_output}/gn:
  override_dh_auto_configure:
  	# output compiler information


### PR DESCRIPTION
See [comment](https://github.com/Eloston/ungoogled-chromium/issues/37#issuecomment-357717417)
Now it should work even without `--ignore-whitespace` option.