### PR TITLE
linux_simple packaging fixes

### DIFF
--- a/buildkit/packaging/linux_simple.py
+++ b/buildkit/packaging/linux_simple.py
@@ -47,6 +47,7 @@ def generate_packaging(config_bundle, output_dir, build_output=DEFAULT_BUILD_OUT
 
     ensure_empty_dir(output_dir) # Raises FileNotFoundError, FileExistsError
     (output_dir / 'scripts').mkdir()
+    (output_dir / 'archive_include').mkdir()
 
     # Build and packaging scripts
     _copy_from_resources('build.sh.in', output_dir)

--- a/resources/packaging/linux_simple/package.sh.in
+++ b/resources/packaging/linux_simple/package.sh.in
@@ -6,14 +6,17 @@ TARPREFIX=ungoogled-chromium_$ungoog{version_string}_linux
 CURRENTDIR=$(dirname $(readlink -f $0))
 # Assume buildspace tree is outside this script's directory
 BUILDSPACE_TREE=$(dirname "$CURRENTDIR")
-ARCHIVE_OUTPUT=$(dirname "$BUILDSPACE_TREE")/$TARPREFIX.tar.xz
+ARCHIVE_OUTPUT=$(dirname "$BUILDSPACE_TREE")/$TARPREFIX.tar
 
 # Include main build outputs
 pushd "$BUILDSPACE_TREE/$ungoog{build_output}"
-"$CURRENTDIR/scripts/list_build_outputs.py" --platform linux --tree "$BUILDSPACE_TREE" --build-outputs '$ungoog{build_output}' | tar --transform "s,^,$TARPREFIX," -c -J -v -f "$ARCHIVE_OUTPUT" --verbatim-files-from -T -
+"$CURRENTDIR/scripts/list_build_outputs.py" --platform linux --tree "$BUILDSPACE_TREE" --build-outputs '$ungoog{build_output}' | tar --transform "s,^,$TARPREFIX/," -c -v -f "$ARCHIVE_OUTPUT" --verbatim-files-from -T -
 popd
 
 # Include additional packaging files
 pushd "$CURRENTDIR/archive_include"
-find -type f -printf '%P\0' | tar --transform "s,^,$TARPREFIX," -r -J -v -f "$ARCHIVE_OUTPUT" --null -T -
+find -type f -printf '%P\0' | tar --transform "s,^,$TARPREFIX/," -r -v -f "$ARCHIVE_OUTPUT" --null -T -
 popd
+
+rm -f "$ARCHIVE_OUTPUT".xz
+xz -z "$ARCHIVE_OUTPUT"


### PR DESCRIPTION
These are some fixes for linux_simple packaging problems that I ran into while trying to build on a Gentoo system

- Script resources (build.sh, packaging.sh, list_build_outputs.py) were not executable after being copied
- linux_simple.py failed because the ungoogled_packaging/scripts directory did not exist
- package.sh failed with `tar: Invalid transform expression`
- package.sh failed with `tar: You must specify one of the '-Acdtrux', '--delete' or '--test-label' options`

Perhaps some of this is related to version differences in the various utilities, I don't know. I'm on an updated Gentoo `~amd64` system