### PR TITLE
archlinux: Update for 65

### DIFF
--- a/resources/config_bundles/archlinux/gn_flags.map
+++ b/resources/config_bundles/archlinux/gn_flags.map
@@ -1,4 +1,2 @@
 custom_toolchain="//build/toolchain/linux/unbundle:default"
 host_toolchain="//build/toolchain/linux/unbundle:default"
-use_system_harfbuzz=true
-use_system_libpng=true

--- a/resources/config_bundles/linux_rooted/gn_flags.map
+++ b/resources/config_bundles/linux_rooted/gn_flags.map
@@ -10,7 +10,6 @@ optimize_for_size=false
 use_allocator="none"
 use_cups=true
 use_custom_libcxx=false
-use_gconf=false
 use_gold=true
 use_gtk3=true
 use_jumbo_build=true

--- a/resources/packaging/archlinux/PKGBUILD.in
+++ b/resources/packaging/archlinux/PKGBUILD.in
@@ -40,7 +40,7 @@ sha256sums=('5fd0218759231ac00cc729235823592f6fd1e4a00ff64780a5fed7ab210f1860'
 # Possible replacements are listed in build/linux/unbundle/replace_gn_files.py
 # Keys are the names in the above script; values are the dependencies in Arch
 readonly -A _system_libs=(
-  #[ffmpeg]=ffmpeg            # https://crbug.com/731766
+  [ffmpeg]=ffmpeg
   [flac]=flac
   [fontconfig]=fontconfig
   [freetype]=freetype2

--- a/resources/packaging/archlinux/PKGBUILD.in
+++ b/resources/packaging/archlinux/PKGBUILD.in
@@ -42,9 +42,9 @@ sha256sums=('5fd0218759231ac00cc729235823592f6fd1e4a00ff64780a5fed7ab210f1860'
 readonly -A _system_libs=(
   #[ffmpeg]=ffmpeg            # https://crbug.com/731766
   [flac]=flac
-  #[fontconfig]=fontconfig    # Enable for M65
-  #[freetype]=freetype2       # Using 'use_system_freetype=true' until M65
-  #[harfbuzz-ng]=harfbuzz     # Using 'use_system_harfbuzz=true' until M65
+  [fontconfig]=fontconfig
+  [freetype]=freetype2
+  [harfbuzz-ng]=harfbuzz
   [icu]=icu
   [libdrm]=
   [libevent]=libevent
@@ -63,10 +63,8 @@ readonly -A _system_libs=(
 readonly _unwanted_bundled_libs=(
   ${!_system_libs[@]}
   ${_system_libs[libjpeg]+libjpeg_turbo}
-  freetype
-  harfbuzz-ng
 )
-depends+=(${_system_libs[@]} freetype2 harfbuzz)
+depends+=(${_system_libs[@]})
 
 prepare() {
   cd "$srcdir/ungoogled-chromium-$ungoog{repo_version}"
@@ -116,7 +114,7 @@ prepare() {
       \! -path "*third_party/$_lib/chromium/*" \
       \! -path "*third_party/$_lib/google/*" \
       \! -path './base/third_party/icu/*' \
-      \! -path './third_party/freetype/src/src/psnames/pstables.h' \
+      \! -path './third_party/pdfium/third_party/freetype/include/pstables.h' \
       \! -path './third_party/yasm/run_yasm.py' \
       \! -regex '.*\.\(gn\|gni\|isolate\)' \
       -delete
@@ -150,13 +148,6 @@ build() {
 $ungoog{gn_flags}
   )
 
-  if check_option strip y; then
-    # https://chromium-review.googlesource.com/c/chromium/src/+/712575
-    # _flags+=('exclude_unwind_tables=true')
-    CFLAGS+='   -fno-unwind-tables -fno-asynchronous-unwind-tables'
-    CXXFLAGS+=' -fno-unwind-tables -fno-asynchronous-unwind-tables'
-    CPPFLAGS+=' -DNO_UNWIND_TABLES'
-  fi
 
   msg2 'Building GN'
   python2 tools/gn/bootstrap/bootstrap.py -o $ungoog{build_output}/gn -s -j 4 --no-clean


### PR DESCRIPTION
- updated gn_flags and PKGBUILD for 65.0.3325.146
- removed use_gconf flag as it is not available in 65
- removed duplicate unwind tables exclusion