### PR TITLE
windows: refresh patches and fix gn bootstrap patch

### DIFF
--- a/resources/patches/ungoogled-chromium/windows/windows-disable-orderfile.patch
+++ b/resources/patches/ungoogled-chromium/windows/windows-disable-orderfile.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -407,22 +407,6 @@ if (is_win) {
+@@ -410,22 +410,6 @@ if (is_win) {
          "//content/public/app:both",
        ]
      }
@@ -25,7 +25,7 @@
    }
  
    if (is_multi_dll_chrome) {
-@@ -471,22 +455,6 @@ if (is_win) {
+@@ -474,22 +458,6 @@ if (is_win) {
          "/DELAYLOAD:wininet.dll",
        ]
  

--- a/resources/patches/ungoogled-chromium/windows/windows-disable-reorder-fix-linking.patch
+++ b/resources/patches/ungoogled-chromium/windows/windows-disable-reorder-fix-linking.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -44,35 +44,6 @@
+@@ -44,35 +44,6 @@ if (enable_resource_whitelist_generation
    chrome_resource_whitelist = "$target_gen_dir/chrome_resource_whitelist.txt"
  }
  
@@ -38,7 +38,7 @@
  # This target exists above chrome and it's main components in the dependency
  # tree as a central place to put assert_no_deps annotations. Since this depends
  # on Chrome and the main DLLs it uses, it will transitively assert that those
-@@ -107,9 +78,6 @@
+@@ -107,9 +78,6 @@ if (!is_android && !is_mac) {
      data_deps = [
        ":chrome_initial",
      ]
@@ -48,7 +48,7 @@
      if (use_aura && (is_win || is_linux)) {
        data_deps += [ "//chrome/app:service_manifests" ]
      }
-@@ -313,11 +281,7 @@
+@@ -316,11 +284,7 @@ if (!is_android && !is_mac) {
    }
  
    chrome_binary("chrome_initial") {
@@ -61,7 +61,7 @@
  
      sources = []
      if (!is_win && use_aura) {
-@@ -394,6 +358,7 @@
+@@ -397,6 +361,7 @@ if (is_win) {
        "//third_party/cld_3/src/src:cld_3",
        "//third_party/wtl",
        "//ui/views",
@@ -71,7 +71,7 @@
      ldflags = [
 --- a/tools/perf/chrome_telemetry_build/BUILD.gn
 +++ b/tools/perf/chrome_telemetry_build/BUILD.gn
-@@ -36,10 +36,6 @@
+@@ -36,10 +36,6 @@ group("telemetry_chrome_test") {
      "//components/crash/content/tools/generate_breakpad_symbols.py",
    ]
  

--- a/resources/patches/ungoogled-chromium/windows/windows-disable-win-build-output.patch
+++ b/resources/patches/ungoogled-chromium/windows/windows-disable-win-build-output.patch
@@ -29,7 +29,7 @@
      if os.path.exists(tmp_dir) and delete_tmp_dir:
 --- a/build/win/message_compiler.py
 +++ b/build/win/message_compiler.py
-@@ -116,23 +116,6 @@ def main():
+@@ -117,23 +117,6 @@ def main():
          header_contents += sorted(define_block, key=lambda s: s.split()[-1])
        with open(header_file, 'wb') as f:
          f.write(''.join(header_contents))

--- a/resources/patches/ungoogled-chromium/windows/windows-fix-gn-bootstrap.patch
+++ b/resources/patches/ungoogled-chromium/windows/windows-fix-gn-bootstrap.patch
@@ -2,7 +2,17 @@
 
 --- a/tools/gn/bootstrap/bootstrap.py
 +++ b/tools/gn/bootstrap/bootstrap.py
-@@ -779,17 +779,16 @@ def write_gn_ninja(path, root_gen_dir, o
+@@ -755,6 +755,9 @@ def write_gn_ninja(path, root_gen_dir, o
+ 
+   if is_win:
+     static_libraries['base']['sources'].extend([
++        'base/allocator/partition_allocator/address_space_randomization.cc',
++        'base/allocator/partition_allocator/page_allocator.cc',
++        'base/allocator/partition_allocator/spin_lock.cc',
+         'base/base_paths_win.cc',
+         'base/cpu.cc',
+         'base/debug/close_handle_hook_win.cc',
+@@ -791,17 +794,16 @@ def write_gn_ninja(path, root_gen_dir, o
          'base/sync_socket_win.cc',
          'base/synchronization/condition_variable_win.cc',
          'base/synchronization/lock_impl_win.cc',
@@ -21,7 +31,7 @@
          'base/win/enum_variant.cc',
          'base/win/event_trace_controller.cc',
          'base/win/event_trace_provider.cc',
-@@ -803,9 +802,11 @@ def write_gn_ninja(path, root_gen_dir, o
+@@ -815,9 +817,11 @@ def write_gn_ninja(path, root_gen_dir, o
          'base/win/registry.cc',
          'base/win/resource_util.cc',
          'base/win/scoped_bstr.cc',


### PR DESCRIPTION
* refresh most windows patches
* fix windows build error in gn bootstrap step with chromium 65
* windows safe browsing patch left untouched and still broken