### PR TITLE
archlinux: Minor changes to PKGBUILD

### DIFF
--- a/resources/packaging/archlinux/PKGBUILD.in
+++ b/resources/packaging/archlinux/PKGBUILD.in
@@ -17,7 +17,7 @@ license=('BSD')
 depends=('gtk3' 'nss' 'alsa-lib' 'xdg-utils' 'libxss' 'libcups' 'libgcrypt'
          'ttf-font' 'systemd' 'dbus' 'libpulse' 'pciutils' 'json-glib'
          'desktop-file-utils' 'hicolor-icon-theme')
-makedepends=('python2' 'gperf' 'yasm' 'mesa' 'ninja' 'nodejs' 'git' 'clang'
+makedepends=('python2' 'gperf' 'yasm' 'mesa' 'ninja' 'git' 'clang'
              'llvm' 'lld' 'libva' 'quilt')
 optdepends=('pepper-flash: support for Flash content'
             'kdialog: needed for file dialogs in KDE'

--- a/resources/packaging/archlinux/PKGBUILD.in
+++ b/resources/packaging/archlinux/PKGBUILD.in
@@ -16,9 +16,9 @@ url="https://github.com/Eloston/ungoogled-chromium"
 license=('BSD')
 depends=('gtk3' 'nss' 'alsa-lib' 'xdg-utils' 'libxss' 'libcups' 'libgcrypt'
          'ttf-font' 'systemd' 'dbus' 'libpulse' 'pciutils' 'json-glib'
-         'desktop-file-utils' 'hicolor-icon-theme' 'libevent')
-makedepends=('python2' 'gperf' 'yasm' 'mesa' 'ninja' 'git' 'libva'
-             'clang' 'llvm' 'lld' 'quilt')
+         'desktop-file-utils' 'hicolor-icon-theme')
+makedepends=('python2' 'gperf' 'yasm' 'mesa' 'ninja' 'nodejs' 'git' 'clang'
+             'llvm' 'lld' 'libva' 'quilt')
 optdepends=('pepper-flash: support for Flash content'
             'kdialog: needed for file dialogs in KDE'
             'gnome-keyring: for storing passwords in GNOME keyring'
@@ -27,7 +27,7 @@ optdepends=('pepper-flash: support for Flash content'
             'libva-mesa-driver: for hardware video acceleration with AMD/ATI GPUs'
             'libva-vdpau-driver: for hardware video acceleration with NVIDIA GPUs')
 provides=('chromium')
-conflicts=('chromium' 'inox' 'iridium')
+conflicts=('chromium')
 source=(https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$pkgver.tar.xz
         chromium-launcher-$_launcher_ver.tar.gz::https://github.com/foutrelis/chromium-launcher/archive/v$_launcher_ver.tar.gz
         chromium-$pkgver.txt::https://chromium.googlesource.com/chromium/src.git/+/$pkgver?format=TEXT
@@ -67,13 +67,16 @@ readonly _unwanted_bundled_libs=(
 depends+=(${_system_libs[@]})
 
 prepare() {
-  cd "$srcdir/ungoogled-chromium-$ungoog{repo_version}"
+  local _tree="$srcdir/chromium-$pkgver"
+  local _user_bundle="$srcdir/chromium-$pkgver/ungoogled
+
+  cd "$srcdir/$pkgname-$pkgver-$pkgrel"
 
   msg2 'Processing sources'
-  python3 buildkit-launcher.py genbun -u "$srcdir/chromium-$pkgver/ungoogled" archlinux
-  python3 buildkit-launcher.py prubin -u "$srcdir/chromium-$pkgver/ungoogled" -t "$srcdir/chromium-$pkgver"
-  python3 buildkit-launcher.py subdom -u "$srcdir/chromium-$pkgver/ungoogled" -t "$srcdir/chromium-$pkgver"
-  cp "$srcdir/chromium-$pkgver/ungoogled/patch_order.list" "$srcdir/chromium-$pkgver/ungoogled/patches/series"
+  python buildkit-launcher.py genbun -u "$_user_bundle" archlinux
+  python buildkit-launcher.py prubin -u "$_user_bundle" -t "$_tree"
+  python buildkit-launcher.py subdom -u "$_user_bundle" -t "$_tree"
+  ln -s ../patch_order.list "$_user_bundle/patches/series"
 
   cd "$srcdir/chromium-$pkgver"
 
@@ -88,7 +91,7 @@ prepare() {
   echo "LASTCHANGE=$_chrome_build_hash-" >build/util/LASTCHANGE
 
   # Apply patches
-  env QUILT_PATCHES="$srcdir/chromium-$pkgver/ungoogled/patches" quilt push -a
+  env QUILT_PATCHES="$_user_bundle/patches" quilt push -a
 
   # Remove compiler flags not supported by our system clang
   sed -i \
@@ -150,7 +153,7 @@ $ungoog{gn_flags}
 
 
   msg2 'Building GN'
-  python2 tools/gn/bootstrap/bootstrap.py -o $ungoog{build_output}/gn -s -j 4 --no-clean
+  python2 tools/gn/bootstrap/bootstrap.py -o $ungoog{build_output}/gn -s --no-clean
   msg2 'Configuring Chromium'
   $ungoog{build_output}/gn gen $ungoog{build_output} --args="${_flags[*]}" \
     --script-executable=/usr/bin/python2 --fail-on-unused-args
@@ -169,7 +172,6 @@ package() {
 
   install -D $ungoog{build_output}/chrome "$pkgdir/usr/lib/chromium/chromium"
   install -Dm4755 $ungoog{build_output}/chrome_sandbox "$pkgdir/usr/lib/chromium/chrome-sandbox"
-  install -D $ungoog{build_output}/chromedriver "$pkgdir/usr/lib/chromium/chromedriver"
   ln -s /usr/lib/$pkgname/chromedriver "$pkgdir/usr/bin/chromedriver"
 
   install -Dm644 chrome/installer/linux/common/desktop.template \
@@ -185,7 +187,7 @@ package() {
 
   cp \
     $ungoog{build_output}/{chrome_{100,200}_percent,resources}.pak \
-    $ungoog{build_output}/{*.bin,libwidevinecdmadapter.so} \
+    $ungoog{build_output}/{*.bin,chromedriver,libwidevinecdmadapter.so} \
     "$pkgdir/usr/lib/chromium/"
   install -Dm644 -t "$pkgdir/usr/lib/chromium/locales" $ungoog{build_output}/locales/*.pak
 

--- a/resources/packaging/archlinux/PKGBUILD.in
+++ b/resources/packaging/archlinux/PKGBUILD.in
@@ -68,7 +68,7 @@ depends+=(${_system_libs[@]})
 
 prepare() {
   local _tree="$srcdir/chromium-$pkgver"
-  local _user_bundle="$srcdir/chromium-$pkgver/ungoogled
+  local _user_bundle="$srcdir/chromium-$pkgver/ungoogled"
 
   cd "$srcdir/$pkgname-$pkgver-$pkgrel"
 


### PR DESCRIPTION
- makedepends array: libevent already defined in _system_libs array ~, added nodejs~
- conflicts array: should only include 'chromium'. Conflicts between possible other packages providing and conflicting with chromium are handled automatically by the package manager
- python3 is default in Arch Linux
- removed hardcoded parallel job amount
- minor changes to match the official Arch Linux PKGBUILD
