### PR TITLE
buildkit: Add support for downloading LLVM on Windows

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -96,9 +96,6 @@ When installing the SDK, the "Debugging Tools for Windows" feature must be enabl
 
 1. Setup the following:
 
-    * [LLVM](https://llvm.org/) 6.0.0 or newer.
-        * To use LLVM's pre-built binary, download the `Clang for Windows (64-bit)` version and unpack it with 7-zip into third_party/llvm-build/Release+Asserts in the buildspace tree.
-        * *Developer note*: If the current stable version of LLVM is causing problems with the build, try matching Google's LLVM version (defined by the `CLANG_REVISION` variable in by downloading a snapshot build at the version specified by `CLANG_REVISION` and `VERSION` constants in `tools/clang/scripts/update.py`. For example, revision 123456 of LLVM 9.8.7 64-bit Windows would be: `http://prereleases.llvm.org/win-snapshots/LLVM-9.8.7-r123456-win64.exe` (link derived from [LLVM Snapshot Builds](http://llvm.org/builds/))
     * Python 2 for scripts in Chromium
     * Python 3 for buildkit
     * [Ninja](https://ninja-build.org/)

--- a/buildkit/cli.py
+++ b/buildkit/cli.py
@@ -190,9 +190,8 @@ def _add_getsrc(subparsers):
               'binary for extraction. Default: %(default)s'))
     parser.add_argument(
         '--7z-path', dest='sevenz_path', default=SEVENZIP_USE_REGISTRY,
-        help=('(Windows only) Command or path to the 7-Zip 7z.exe binary. If '
-              '"_use_registry" is specified, determine the path from the registry. '
-              'Default: %(default)s'))
+        help=('Command or path to 7-Zip\'s "7z" binary. If "_use_registry" is '
+              'specified, determine the path from the registry. Default: %(default)s'))
     parser.set_defaults(callback=_callback)
 
 def _add_prubin(subparsers):

--- a/buildkit/cli.py
+++ b/buildkit/cli.py
@@ -136,9 +136,14 @@ def _add_getsrc(subparsers):
     """Downloads, checks, and unpacks the necessary files into the buildspace tree"""
     def _callback(args):
         try:
+            user_binaries = {}
+            if args.tar_path is not None:
+                user_binaries['tar'] = args.tar_path
+            if args.sevenz_path is not None:
+                user_binaries['7z'] = args.sevenz_path
             source_retrieval.retrieve_and_extract(
                 args.bundle, args.downloads, args.tree, prune_binaries=args.prune_binaries,
-                show_progress=args.show_progress)
+                show_progress=args.show_progress, user_binaries=user_binaries)
         except FileExistsError as exc:
             get_logger().error('Directory is not empty: %s', exc)
             raise _CLIError()
@@ -179,6 +184,10 @@ def _add_getsrc(subparsers):
     parser.add_argument(
         '--hide-progress-bar', action='store_false', dest='show_progress',
         help='Hide the download progress.')
+    parser.add_argument(
+        '--tar-path', help='Path to the tar binary.')
+    parser.add_argument(
+        '--7z-path', help='Path to the 7z.exe binary.', dest='sevenz_path')
     parser.set_defaults(callback=_callback)
 
 def _add_prubin(subparsers):

--- a/buildkit/common.py
+++ b/buildkit/common.py
@@ -8,6 +8,7 @@
 
 import os
 import logging
+import platform
 from pathlib import Path
 
 # Constants
@@ -105,3 +106,12 @@ def ensure_empty_dir(path, parents=False):
     except FileExistsError as exc:
         if not dir_empty(path):
             raise exc
+
+def is_windows_platform():
+    """
+    Returns True if we are running on a Windows platform, either natively or
+    inside WSL/MSYS2
+    """
+    uname = platform.uname()
+    # detect native python and WSL
+    return uname.system == 'Windows' or 'Microsoft' in uname.release

--- a/buildkit/common.py
+++ b/buildkit/common.py
@@ -6,6 +6,7 @@
 
 """Common code and constants"""
 
+import enum
 import os
 import logging
 import platform
@@ -24,6 +25,8 @@ BUILDSPACE_TREE = 'buildspace/tree'
 BUILDSPACE_TREE_PACKAGING = 'buildspace/tree/ungoogled_packaging'
 BUILDSPACE_USER_BUNDLE = 'buildspace/user_bundle'
 
+SEVENZIP_USE_REGISTRY = '_use_registry'
+
 _ENV_FORMAT = "BUILDKIT_{}"
 
 # Public classes
@@ -37,6 +40,16 @@ class BuildkitAbort(BuildkitError):
 
     It should only be caught by the user of buildkit's library interface.
     """
+
+class PlatformEnum(enum.Enum):
+    """Enum for platforms that need distinction for certain functionality"""
+    UNIX = 'unix' # Currently covers anything that isn't Windows
+    WINDOWS = 'windows'
+
+class ExtractorEnum: #pylint: disable=too-few-public-methods
+    """Enum for extraction binaries"""
+    SEVENZIP = '7z'
+    TAR = 'tar'
 
 # Public methods
 
@@ -107,11 +120,16 @@ def ensure_empty_dir(path, parents=False):
         if not dir_empty(path):
             raise exc
 
-def is_windows_platform():
+def get_running_platform():
     """
-    Returns True if we are running on a Windows platform, either natively or
-    inside WSL/MSYS2
+    Returns a PlatformEnum value indicating the platform that buildkit is running on.
+
+    NOTE: Platform detection should only be used when no cross-platform alternative is available.
     """
     uname = platform.uname()
     # detect native python and WSL
-    return uname.system == 'Windows' or 'Microsoft' in uname.release
+    if uname.system == 'Windows' or 'Microsoft' in uname.release:
+        return PlatformEnum.WINDOWS
+    else:
+        # Only Windows and UNIX-based platforms need to be distinguished right now.
+        return PlatformEnum.UNIX

--- a/buildkit/config.py
+++ b/buildkit/config.py
@@ -18,7 +18,7 @@ import shutil
 from pathlib import Path
 
 from .common import (
-    ENCODING, CONFIG_BUNDLES_DIR, BuildkitAbort,
+    ENCODING, CONFIG_BUNDLES_DIR, BuildkitAbort, ExtractorEnum,
     get_logger, get_resources_dir, ensure_empty_dir)
 from .third_party import schema
 
@@ -619,13 +619,14 @@ class ExtraDepsIni(IniConfigFile):
 
     _hashes = ('md5', 'sha1', 'sha256', 'sha512')
     _required_keys = ('version', 'url', 'download_name')
-    _optional_keys = ('strip_leading_dirs','extractor')
-    _passthrough_properties = (*_required_keys, *_optional_keys)
+    _optional_keys = ('strip_leading_dirs')
+    _passthrough_properties = (*_required_keys, *_optional_keys, 'extractor')
 
     _schema = schema.Schema(schema_inisections({
         schema.Optional(schema.And(str, len)): schema_dictcast({
             **{x: schema.And(str, len) for x in _required_keys},
             **{schema.Optional(x): schema.And(str, len) for x in _optional_keys},
+            schema.Optional('extractor'): schema.Or(ExtractorEnum.TAR, ExtractorEnum.SEVENZIP),
             schema.Or(*_hashes): schema.And(str, len),
         })
     }))

--- a/buildkit/config.py
+++ b/buildkit/config.py
@@ -619,7 +619,7 @@ class ExtraDepsIni(IniConfigFile):
 
     _hashes = ('md5', 'sha1', 'sha256', 'sha512')
     _required_keys = ('version', 'url', 'download_name')
-    _optional_keys = ('strip_leading_dirs',)
+    _optional_keys = ('strip_leading_dirs','extractor')
     _passthrough_properties = (*_required_keys, *_optional_keys)
 
     _schema = schema.Schema(schema_inisections({

--- a/buildkit/config.py
+++ b/buildkit/config.py
@@ -619,7 +619,7 @@ class ExtraDepsIni(IniConfigFile):
 
     _hashes = ('md5', 'sha1', 'sha256', 'sha512')
     _required_keys = ('version', 'url', 'download_name')
-    _optional_keys = ('strip_leading_dirs')
+    _optional_keys = ('strip_leading_dirs',)
     _passthrough_properties = (*_required_keys, *_optional_keys, 'extractor')
 
     _schema = schema.Schema(schema_inisections({

--- a/buildkit/extractors.py
+++ b/buildkit/extractors.py
@@ -232,8 +232,8 @@ def extract_tar_file(archive_path, buildspace_tree, unpack_dir, ignore_files, re
 def extract_with_7z(archive_path, buildspace_tree, unpack_dir, ignore_files, relative_to, #pylint: disable=too-many-arguments
                     extractors=None):
     """
-    (Windows only) Extract archives with 7-zip into the buildspace tree.
-    Only supports archives with one layer of unpacking, unlike compressed tar archives.
+    Extract archives with 7-zip into the buildspace tree.
+    Only supports archives with one layer of unpacking, so compressed tar archives don't work.
 
     archive_path is the pathlib.Path to the archive to unpack
     buildspace_tree is a pathlib.Path to the buildspace tree.

--- a/buildkit/extractors.py
+++ b/buildkit/extractors.py
@@ -37,7 +37,7 @@ def _find_7z_by_registry():
     except OSError:
         get_logger().exception('Unable to locate 7-zip from the Windows Registry')
         raise BuildkitAbort()
-    sevenzip_path = Path(sevenzipfm_dir / '7z.exe')
+    sevenzip_path = Path(sevenzipfm_dir) / '7z.exe'
     if not sevenzip_path.is_file():
         get_logger().error('7z.exe not found at path from registry: %s', sevenzip_path)
     return sevenzip_path

--- a/buildkit/extractors.py
+++ b/buildkit/extractors.py
@@ -1,0 +1,202 @@
+# -*- coding: UTF-8 -*-
+
+# Copyright (c) 2018 The ungoogled-chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""
+Archive extraction utilities
+"""
+
+import os
+import shutil
+import subprocess
+import tarfile
+from pathlib import Path, PurePosixPath
+
+from .common import ENCODING, BuildkitAbort, get_logger, ensure_empty_dir, is_windows_platform
+
+def _process_relative_to(unpack_root, relative_to):
+    """
+    For an extractor that doesn't support an automatic transform, move the extracted
+    contents from the relative_to/ directory to the unpack_root
+    """
+    relative_root = unpack_root / relative_to
+    if not relative_root.is_dir():
+        raise Exception('Could not find relative_to directory in extracted files: {}', relative_to)
+    for src_path in relative_root.iterdir():
+        dest_path = unpack_root / src_path.name
+        src_path.rename(dest_path)
+    relative_root.rmdir()
+
+def _prune_tree(unpack_root, ignore_files):
+    """
+    Run through the list of pruned files, delete them, and remove them from the set
+    """
+    deleted_files = []
+    for relative_file in ignore_files:
+        file = unpack_root / relative_file
+        if not file.is_file():
+            continue
+        file.unlink()
+        deleted_files.append((Path(relative_file).as_posix()))
+    for d in deleted_files:
+        ignore_files.remove(d)
+
+def _extract_tar_file_7z(binary, tar_path, buildspace_tree, unpack_dir, ignore_files, relative_to):
+    out_dir = buildspace_tree / unpack_dir
+    cmd1 = [binary, 'x', str(tar_path), '-so']
+    cmd2 = [binary, 'x', '-si', '-aoa', '-ttar', '-o{}'.format(str(out_dir))]
+    cmdline = '{} | {}'.format(' '.join(cmd1), ' '.join(cmd2))
+    get_logger().debug("7z command line: {}".format(cmdline))
+
+    p1 = subprocess.Popen(cmd1, stdout=subprocess.PIPE)
+    p2 = subprocess.Popen(cmd2, stdin=p1.stdout, stdout=subprocess.PIPE)
+    p1.stdout.close()
+    (stdout_data, stderr_data) = p2.communicate()
+    if p2.returncode != 0:
+        get_logger().debug('stdout: {}'.format(stdout_data))
+        get_logger().debug('stderr: {}'.format(stderr_data))
+        raise Exception('7z commands returned non-zero status: {}'.format(p2.returncode))
+
+    if relative_to is not None:
+        _process_relative_to(out_dir, relative_to)
+
+    _prune_tree(out_dir, ignore_files)
+
+def _extract_tar_file_tar(binary, tar_path, buildspace_tree, unpack_dir, ignore_files, relative_to):
+    out_dir = buildspace_tree / unpack_dir
+    out_dir.mkdir(exist_ok=True)
+    cmd = [binary, '-xf', str(tar_path), '-C', str(out_dir)]
+    cmdline = ' '.join(cmd)
+    get_logger().debug("tar command line: {}".format(cmdline))
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        raise Exception('tar command returned {}'.format(result.returncode))
+
+    # for gnu tar, the --transform option could be used. but to keep compatibility with
+    # bsdtar on macos, we just do this ourselves
+    if relative_to is not None:
+        _process_relative_to(out_dir, relative_to)
+
+    _prune_tree(out_dir, ignore_files)
+
+def _extract_tar_file_python(tar_path, buildspace_tree, unpack_dir, ignore_files, relative_to):
+
+    class NoAppendList(list):
+        """Hack to workaround memory issues with large tar files"""
+        def append(self, obj):
+            pass
+
+    # Simple hack to check if symlinks are supported
+    try:
+        os.symlink('', '')
+    except FileNotFoundError:
+        # Symlinks probably supported
+        symlink_supported = True
+    except OSError:
+        # Symlinks probably not supported
+        get_logger().info('System does not support symlinks. Ignoring them.')
+        symlink_supported = False
+    except BaseException:
+        # Unexpected exception
+        get_logger().exception('Unexpected exception during symlink support check.')
+        raise BuildkitAbort()
+
+    with tarfile.open(str(tar_path)) as tar_file_obj:
+        tar_file_obj.members = NoAppendList()
+        for tarinfo in tar_file_obj:
+            try:
+                if relative_to is None:
+                    tree_relative_path = unpack_dir / PurePosixPath(tarinfo.name)
+                else:
+                    tree_relative_path = unpack_dir / PurePosixPath(tarinfo.name).relative_to(
+                        relative_to) # pylint: disable=redefined-variable-type
+                try:
+                    ignore_files.remove(tree_relative_path.as_posix())
+                except KeyError:
+                    destination = buildspace_tree / tree_relative_path
+                    if tarinfo.issym() and not symlink_supported:
+                        # In this situation, TarFile.makelink() will try to create a copy of the
+                        # target. But this fails because TarFile.members is empty
+                        # But if symlinks are not supported, it's safe to assume that symlinks
+                        # aren't needed. The only situation where this happens is on Windows.
+                        continue
+                    if tarinfo.islnk():
+                        # Derived from TarFile.extract()
+                        new_target = buildspace_tree / unpack_dir / PurePosixPath(
+                            tarinfo.linkname).relative_to(relative_to)
+                        tarinfo._link_target = new_target.as_posix() # pylint: disable=protected-access
+                    if destination.is_symlink():
+                        destination.unlink()
+                    tar_file_obj._extract_member(tarinfo, str(destination)) # pylint: disable=protected-access
+            except BaseException:
+                get_logger().exception('Exception thrown for tar member: %s', tarinfo.name)
+                raise BuildkitAbort()
+
+def extract_tar_file(tar_path, buildspace_tree, unpack_dir, ignore_files, relative_to, user_binaries):
+    """
+    One-time tar extraction function
+
+    tar_path is the pathlib.Path to the archive to unpack
+    buildspace_tree is a pathlib.Path to the buildspace tree.
+    unpack_dir is a pathlib.Path relative to buildspace_tree to unpack the archive.
+    It must already exist.
+
+    ignore_files is a set of paths as strings that should not be extracted from the archive.
+    Files that have been ignored are removed from the set.
+    relative_to is a pathlib.Path for directories that should be stripped relative to the
+    root of the archive.
+    user_binaries is a dict of user-provided utility binaries, if available
+
+    Raises BuildkitAbort if unexpected issues arise during unpacking.
+    """
+
+    def lookup_binary(name):
+        return user_binaries.get(name) or shutil.which(name)
+
+    tar_bin = lookup_binary('tar')
+    sevenz_bin = lookup_binary('7z')
+    resolved_tree = buildspace_tree.resolve()
+    common_args = [tar_path, resolved_tree, unpack_dir, ignore_files, relative_to]
+
+    if is_windows_platform():
+        if sevenz_bin is not None:
+            _extract_tar_file_7z(sevenz_bin, *common_args)
+        else:
+            get_logger().info('7z.exe not found. Using built-in Python extractor')
+            _extract_tar_file_python(*common_args)
+    else:
+        if tar_bin is not None:
+            _extract_tar_file_tar(tar_bin, *common_args)
+        else:
+             # we dont try 7z on unix because it doesnt preserve file permissions
+            get_logger().info('tar command not found. Using built-in Python extractor')
+            _extract_tar_file_python(*common_args)
+
+def extract_7z_file(tar_path, buildspace_tree, unpack_dir, ignore_files, relative_to, user_binaries):
+
+    """
+    One-time 7zip extraction function
+
+    Same arguments as extract_tar_file
+    """
+    sevenz_bin = user_binaries.get('7z') or shutil.which('7z')
+    if sevenz_bin is None:
+        raise Exception('Unable to locate 7z binary')
+    resolved_tree = buildspace_tree.resolve()
+    common_args = [tar_path, resolved_tree, unpack_dir, ignore_files, relative_to]
+
+    out_dir = resolved_tree / unpack_dir
+    cmd = [sevenz_bin, 'x', str(tar_path), '-aoa', '-o{}'.format(str(out_dir))]
+    cmdline = ' '.join(cmd)
+    get_logger().debug("7z command line: {}".format(cmdline))
+
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        raise Exception('7z command returned {}'.format(result.returncode))
+
+    if relative_to is not None:
+        _process_relative_to(out_dir, relative_to)
+
+    _prune_tree(out_dir, ignore_files)

--- a/buildkit/source_retrieval.py
+++ b/buildkit/source_retrieval.py
@@ -8,14 +8,13 @@
 Module for the downloading, checking, and unpacking of necessary files into the buildspace tree
 """
 
-import os
-import tarfile
 import urllib.request
 import hashlib
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 
-from .common import ENCODING, BuildkitAbort, get_logger, ensure_empty_dir
-from .extractors import extract_tar_file, extract_7z_file
+from .common import (
+    ENCODING, ExtractorEnum, get_logger, ensure_empty_dir)
+from .extractors import extract_tar_file, extract_with_7z
 
 # Constants
 
@@ -83,14 +82,16 @@ def _chromium_hashes_generator(hashes_path):
         else:
             get_logger().warning('Skipping unknown hash algorithm: %s', hash_name)
 
-def _setup_chromium_source(config_bundle, buildspace_downloads, buildspace_tree,
-                           show_progress, pruning_set, user_binaries):
+def _setup_chromium_source(config_bundle, buildspace_downloads, buildspace_tree, #pylint: disable=too-many-arguments
+                           show_progress, pruning_set, extractors=None):
     """
     Download, check, and extract the Chromium source code into the buildspace tree.
 
     Arguments of the same name are shared with retreive_and_extract().
     pruning_set is a set of files to be pruned. Only the files that are ignored during
     extraction are removed from the set.
+    extractors is a dictionary of PlatformEnum to a command or path to the
+    extractor binary. Defaults to 'tar' for tar, and '_use_registry' for 7-Zip.
 
     Raises source_retrieval.HashMismatchError when the computed and expected hashes do not match.
     Raises source_retrieval.NotAFileError when the archive name exists but is not a file.
@@ -123,18 +124,22 @@ def _setup_chromium_source(config_bundle, buildspace_downloads, buildspace_tree,
         if not hasher.hexdigest().lower() == hash_hex.lower():
             raise HashMismatchError(source_archive)
     get_logger().info('Extracting archive...')
-    extract_tar_file(source_archive, buildspace_tree, Path(), pruning_set,
-                      Path('chromium-{}'.format(config_bundle.version.chromium_version)),
-                      user_binaries)
+    extract_tar_file(
+        archive_path=source_archive, buildspace_tree=buildspace_tree, unpack_dir=Path(),
+        ignore_files=pruning_set,
+        relative_to=Path('chromium-{}'.format(config_bundle.version.chromium_version)),
+        extractors=extractors)
 
-def _setup_extra_deps(config_bundle, buildspace_downloads, buildspace_tree, show_progress,
-                      pruning_set, user_binaries):
+def _setup_extra_deps(config_bundle, buildspace_downloads, buildspace_tree, show_progress, #pylint: disable=too-many-arguments,too-many-locals
+                      pruning_set, extractors=None):
     """
     Download, check, and extract extra dependencies into the buildspace tree.
 
     Arguments of the same name are shared with retreive_and_extract().
     pruning_set is a set of files to be pruned. Only the files that are ignored during
     extraction are removed from the set.
+    extractors is a dictionary of PlatformEnum to a command or path to the
+    extractor binary. Defaults to 'tar' for tar, and '_use_registry' for 7-Zip.
 
     Raises source_retrieval.HashMismatchError when the computed and expected hashes do not match.
     Raises source_retrieval.NotAFileError when the archive name exists but is not a file.
@@ -154,30 +159,35 @@ def _setup_extra_deps(config_bundle, buildspace_downloads, buildspace_tree, show
             if not hasher.hexdigest().lower() == hash_hex.lower():
                 raise HashMismatchError(dep_archive)
         get_logger().info('Extracting archive...')
-        extractors = {'7z': extract_7z_file, 'tar': extract_tar_file}
-        extractor_name = dep_properties.extractor or 'tar'
-        extractor_fn = extractors.get(extractor_name)
-        if extractor_fn is None:
-            raise Exception('Unknown extractor: {}. Supported values: {}'
-                .format(extractor_name, [k for k in extractors.keys()]))
+        extractor_name = dep_properties.extractor or ExtractorEnum.TAR
+        if extractor_name == ExtractorEnum.SEVENZIP:
+            extractor_func = extract_with_7z
+        elif extractor_name == ExtractorEnum.TAR:
+            extractor_func = extract_tar_file
+        else:
+            # This is not a normal code path
+            raise NotImplementedError(extractor_name)
 
         if dep_properties.strip_leading_dirs is None:
             strip_leading_dirs_path = None
         else:
             strip_leading_dirs_path = Path(dep_properties.strip_leading_dirs)
 
-        extractor_fn(dep_archive, buildspace_tree, Path(dep_name), pruning_set,
-                          strip_leading_dirs_path, user_binaries)
+        extractor_func(
+            archive_path=dep_archive, buildspace_tree=buildspace_tree,
+            unpack_dir=Path(dep_name), ignore_files=pruning_set,
+            relative_to=strip_leading_dirs_path, extractors=extractors)
 
-def retrieve_and_extract(config_bundle, buildspace_downloads, buildspace_tree,
-                         prune_binaries=True, show_progress=True, user_binaries={}):
+def retrieve_and_extract(config_bundle, buildspace_downloads, buildspace_tree, #pylint: disable=too-many-arguments
+                         prune_binaries=True, show_progress=True, extractors=None):
     """
     Downloads, checks, and unpacks the Chromium source code and extra dependencies
     defined in the config bundle into the buildspace tree.
-    Currently for extra dependencies, only compressed tar files are supported.
 
     buildspace_downloads is the path to the buildspace downloads directory, and
     buildspace_tree is the path to the buildspace tree.
+    extractors is a dictionary of PlatformEnum to a command or path to the
+    extractor binary. Defaults to 'tar' for tar, and '_use_registry' for 7-Zip.
 
     Raises FileExistsError when the buildspace tree already exists and is not empty
     Raises FileNotFoundError when buildspace/downloads does not exist or through
@@ -197,10 +207,14 @@ def retrieve_and_extract(config_bundle, buildspace_downloads, buildspace_tree,
         remaining_files = set(config_bundle.pruning)
     else:
         remaining_files = set()
-    _setup_chromium_source(config_bundle, buildspace_downloads, buildspace_tree, show_progress,
-                           remaining_files, user_binaries)
-    _setup_extra_deps(config_bundle, buildspace_downloads, buildspace_tree, show_progress,
-                      remaining_files, user_binaries)
+    _setup_chromium_source(
+        config_bundle=config_bundle, buildspace_downloads=buildspace_downloads,
+        buildspace_tree=buildspace_tree, show_progress=show_progress,
+        pruning_set=remaining_files, extractors=extractors)
+    _setup_extra_deps(
+        config_bundle=config_bundle, buildspace_downloads=buildspace_downloads,
+        buildspace_tree=buildspace_tree, show_progress=show_progress,
+        pruning_set=remaining_files, extractors=extractors)
     if remaining_files:
         logger = get_logger()
         for path in remaining_files:

--- a/resources/config_bundles/windows/extra_deps.ini
+++ b/resources/config_bundles/windows/extra_deps.ini
@@ -1,13 +1,27 @@
-# Extra dependencies not included in the main Chromium source archive
-# For now, contains the heavily modified syzygy project that builds swapimport.exe
+# Extra dependencies not included in the main Chromium source archive, and
+# additional build utilities to replace Google-provided ones.
+# Do note that utilities in here can be swapped with user-provided versions.
 
-# Disable swapimport / syzygy for now
+# TODO: Perhaps download ninja, gperf, and bison?
+
+# Uses a heavily modified syzygy code base to build swapimport.exe
+# Disabled import reordering for now since this is too much work to maintain
 #[third_party/syzygy]
 #version = bd0e67f571063e18e7200c72e6152a3a7e4c2a6d
 #url = https://github.com/Eloston/syzygy/archive/{version}.tar.gz
 #download_name = syzygy-{version}.tar.gz
 #strip_leading_dirs = syzygy-{version}
 
+# Use a pre-built LLVM toolchain from LLVM for convenience
+# Developer notes:
+# * Releases of LLVM are available as "Clang for Windows (64-bit)" on LLVM's download page.
+# * If the current stable version of LLVM is causing problems with the build, try
+#   matching Google's LLVM version (defined by the `CLANG_REVISION` variable in by
+#   downloading a snapshot build at the version specified by `CLANG_REVISION` and
+#   `VERSION` constants in `tools/clang/scripts/update.py`. For example,
+#   revision 123456 of LLVM 9.8.7 64-bit Windows would be:
+#   `http://prereleases.llvm.org/win-snapshots/LLVM-9.8.7-r123456-win64.exe`
+#   (link derived from [LLVM Snapshot Builds](http://llvm.org/builds/))
 [third_party/llvm-build/Release+Asserts]
 version = 6.0.0
 url = http://releases.llvm.org/%(version)s/LLVM-%(version)s-win64.exe

--- a/resources/config_bundles/windows/extra_deps.ini
+++ b/resources/config_bundles/windows/extra_deps.ini
@@ -7,3 +7,10 @@
 #url = https://github.com/Eloston/syzygy/archive/{version}.tar.gz
 #download_name = syzygy-{version}.tar.gz
 #strip_leading_dirs = syzygy-{version}
+
+[third_party/llvm-build/Release+Asserts]
+version = 6.0.0
+url = http://releases.llvm.org/%(version)s/LLVM-%(version)s-win64.exe
+download_name = LLVM-%(version)s-win64.exe
+sha512 = d61b51582f3011f00a130b7e858e36732bb0253d3d17a31d1de1eb8032bec2887caeeae303d2b38b04f517474ebe416f2c6670abb1049225919ff120e56e91d2
+extractor = 7z


### PR DESCRIPTION
* Add support for multiple extractors in buildkit
* Add support for native tarfile extraction using tar and 7z utilities
* Add extra dependency for LLVM windows binaries