### PR TITLE
buildkit: Add option to disable ssl verification

### DIFF
--- a/buildkit/cli.py
+++ b/buildkit/cli.py
@@ -153,7 +153,8 @@ def _add_getsrc(subparsers):
             source_retrieval.retrieve_and_extract(
                 config_bundle=args.bundle, buildspace_downloads=args.downloads,
                 buildspace_tree=args.tree, prune_binaries=args.prune_binaries,
-                show_progress=args.show_progress, extractors=extractors)
+                show_progress=args.show_progress, extractors=extractors,
+                disable_ssl_verification=args.disable_ssl_verification)
         except FileExistsError as exc:
             get_logger().error('Directory is not empty: %s', exc)
             raise _CLIError()
@@ -202,6 +203,7 @@ def _add_getsrc(subparsers):
         '--7z-path', dest='sevenz_path', default=SEVENZIP_USE_REGISTRY,
         help=('Command or path to 7-Zip\'s "7z" binary. If "_use_registry" is '
               'specified, determine the path from the registry. Default: %(default)s'))
+    parser.add_argument('--disable-ssl-verification', action='store_true')
     parser.set_defaults(callback=_callback)
 
 def _add_prubin(subparsers):

--- a/buildkit/source_retrieval.py
+++ b/buildkit/source_retrieval.py
@@ -179,7 +179,8 @@ def _setup_extra_deps(config_bundle, buildspace_downloads, buildspace_tree, show
             relative_to=strip_leading_dirs_path, extractors=extractors)
 
 def retrieve_and_extract(config_bundle, buildspace_downloads, buildspace_tree, #pylint: disable=too-many-arguments
-                         prune_binaries=True, show_progress=True, extractors=None):
+                         prune_binaries=True, show_progress=True, extractors=None,
+                         disable_ssl_verification=False):
     """
     Downloads, checks, and unpacks the Chromium source code and extra dependencies
     defined in the config bundle into the buildspace tree.
@@ -198,6 +199,10 @@ def retrieve_and_extract(config_bundle, buildspace_downloads, buildspace_tree, #
     Raises source_retrieval.HashMismatchError when the computed and expected hashes do not match.
     May raise undetermined exceptions during archive unpacking.
     """
+    if disable_ssl_verification:
+        import ssl
+        get_logger().info('Disabling SSL verification')
+        ssl._create_default_https_context = ssl._create_unverified_context
     ensure_empty_dir(buildspace_tree) # FileExistsError, FileNotFoundError
     if not buildspace_downloads.exists():
         raise FileNotFoundError(buildspace_downloads)


### PR DESCRIPTION
On a clean, fully updated installation of Windows 2016 with Python 3.6.4 the downloads fail on the SSL verification step. This adds an option (off by default) to disable ssl verification. Note that we are still verifying hashes of all the downloaded files either way.