### PR TITLE
Fix domain_substitution.list to generate Visual Studio Project with gn.exe

### DIFF
--- a/resources/config_bundles/common/domain_substitution.list
+++ b/resources/config_bundles/common/domain_substitution.list
@@ -10481,7 +10481,6 @@ tools/gn/args.cc
 tools/gn/bin/gn-format.py
 tools/gn/bin/roll_gn.py
 tools/gn/standard_out.cc
-tools/gn/visual_studio_writer.cc
 tools/gn/xcode_object.h
 tools/grit/PRESUBMIT.py
 tools/grit/grit/format/android_xml.py
@@ -10514,7 +10513,6 @@ tools/gyp/PRESUBMIT.py
 tools/gyp/buildbot/buildbot_run.py
 tools/gyp/gyptest.py
 tools/gyp/pylib/gyp/MSVSVersion.py
-tools/gyp/pylib/gyp/generator/msvs.py
 tools/gyp/pylib/gyp/generator/ninja.py
 tools/gyp/pylib/gyp/input.py
 tools/gyp/pylib/gyp/msvs_emulation.py


### PR DESCRIPTION
Fix domain_substitution.list to enable to generate Visual Studio Project with gn.exe