### PR TITLE
Update config and packaging for Arch Linux

### DIFF
--- a/config_bundles/archlinux/gn_flags.map
+++ b/config_bundles/archlinux/gn_flags.map
@@ -1,0 +1,1 @@
+'use_cfi_icall=false'

--- a/packaging/archlinux/PKGBUILD.ungoogin
+++ b/packaging/archlinux/PKGBUILD.ungoogin
@@ -18,7 +18,7 @@ depends=('gtk3' 'nss' 'alsa-lib' 'xdg-utils' 'libxss' 'libcups' 'libgcrypt'
          'ttf-font' 'systemd' 'dbus' 'libpulse' 'pciutils' 'json-glib'
          'desktop-file-utils' 'hicolor-icon-theme')
 makedepends=('python' 'python2' 'gperf' 'yasm' 'mesa' 'ninja' 'git'
-             'clang' 'lld' 'llvm' 'libva' 'quilt')
+             'clang' 'lld' 'gn' 'llvm' 'libva' 'quilt')
 optdepends=('pepper-flash: support for Flash content'
             'kdialog: needed for file dialogs in KDE'
             'gnome-keyring: for storing passwords in GNOME keyring'
@@ -52,7 +52,7 @@ declare -gA _system_libs=(
   #[libpng]=libpng            # https://crbug.com/752403#c10
   [libvpx]=libvpx
   [libwebp]=libwebp
-  #[libxml]=libxml2           # https://crbug.com/736026
+  [libxml]=libxml2
   [libxslt]=libxslt
   [opus]=opus
   [re2]=re2
@@ -135,13 +135,8 @@ build() {
   CXXFLAGS+=' -Wno-builtin-macro-redefined'
   CPPFLAGS+=' -D__DATE__=  -D__TIME__=  -D__TIMESTAMP__='
 
-  msg2 'Building GN'
-  python2 tools/gn/bootstrap/bootstrap.py -o out/Default/gn -s --no-clean
   msg2 'Configuring Chromium'
-  python 
-  out/Default/gn gen out/Default \
-    --script-executable=/usr/bin/python2 --fail-on-unused-args
-
+  gn gen out/Default --script-executable=/usr/bin/python2 --fail-on-unused-args
   msg2 'Building Chromium'
   ninja -C out/Default chrome chrome_sandbox chromedriver
 }


### PR DESCRIPTION
CFI seems to break VA-API and the GN flag `use_cfi_icall=false` is used as a workaround. Should other distributions show the same issue, then it is probably better to move the flag to the `linux_rooted` config bundle instead.