### PR TITLE
packaging/arch: Change dir in build to generate gn args

### DIFF
--- a/packaging/archlinux/PKGBUILD.ungoogin
+++ b/packaging/archlinux/PKGBUILD.ungoogin
@@ -119,7 +119,13 @@ build() {
   export NM=llvm-nm
 
   mkdir -p out/Default
-  python -m buildkit gnargs print -b config_bundles/archlinux > out/Default/args.gn
+
+  cd "$srcdir/$pkgname-$ungoog{current_commit}"
+
+  python -m buildkit gnargs print -b config_bundles/archlinux \
+    > "$srcdir/chromium-$pkgver/out/Default/args.gn"
+
+  cd "$srcdir/chromium-$pkgver"
 
   # Facilitate deterministic builds (taken from build/config/compiler/BUILD.gn)
   CFLAGS+='   -Wno-builtin-macro-redefined'


### PR DESCRIPTION
Not sure if there's a more elegant way to pull this off, but this change produced a successful local build