### PR TITLE
docs/building: Remove trailing slash from archlinux command

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -170,7 +170,7 @@ Requirements: Python 3 is needed to generate the PKGBUILD. The PKGBUILD contains
 Generate the PKGBUILD:
 
 ```
-./get_package.py archlinux ./
+./get_package.py archlinux .
 ```
 
 A PKGBUILD will be generated in the current directory. It is a standalone file that can be relocated as necessary.


### PR DESCRIPTION
The current example command for generating a `PKGBUILD` errors out with the following:

```
Traceback (most recent call last):
  File "./get_package.py", line 208, in <module>
    main()
  File "./get_package.py", line 181, in main
    _process_templates(args.destination, packaging_subs)
  File "./get_package.py", line 68, in _process_templates
    content = _BuildFileStringTemplate(new_file.read()).substitute(**build_file_subs)
  File "/usr/lib/python3.7/string.py", line 132, in substitute
    return self.pattern.sub(convert, self.template)
  File "/usr/lib/python3.7/string.py", line 125, in convert
    return str(mapping[named])
KeyError: 'numbered_patch_list'
```