### PR TITLE
packaging/arch: Curl pkgver's hashes for sha256 verification

### DIFF
--- a/packaging/archlinux/PKGBUILD.ungoogin
+++ b/packaging/archlinux/PKGBUILD.ungoogin
@@ -30,11 +30,9 @@ provides=('chromium')
 conflicts=('chromium')
 source=(https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$pkgver.tar.xz
         chromium-launcher-$_launcher_ver.tar.gz::https://github.com/foutrelis/chromium-launcher/archive/v$_launcher_ver.tar.gz
-        chromium-$pkgver.txt::https://chromium.googlesource.com/chromium/src/+/$pkgver?format=TEXT
         'https://github.com/Eloston/ungoogled-chromium/archive/$ungoog{current_commit}.tar.gz')
 sha256sums=($(curl -sL https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${pkgver}.tar.xz.hashes | grep sha256 | cut -d ' ' -f3)
             '04917e3cd4307d8e31bfb0027a5dce6d086edb10ff8a716024fbb8bb0c7dccf1'
-            '0be4bc2e759d2d6136f9baa1d4624aefbababe0cbbd2d1632b76f01654d70524'
             'SKIP')
 
 # Possible replacements are listed in build/linux/unbundle/replace_gn_files.py

--- a/packaging/archlinux/PKGBUILD.ungoogin
+++ b/packaging/archlinux/PKGBUILD.ungoogin
@@ -32,7 +32,7 @@ source=(https://commondatastorage.googleapis.com/chromium-browser-official/chrom
         chromium-launcher-$_launcher_ver.tar.gz::https://github.com/foutrelis/chromium-launcher/archive/v$_launcher_ver.tar.gz
         chromium-$pkgver.txt::https://chromium.googlesource.com/chromium/src/+/$pkgver?format=TEXT
         'https://github.com/Eloston/ungoogled-chromium/archive/$ungoog{current_commit}.tar.gz')
-sha256sums=('73bfa25d41c432ba5a542b20043b62118bc8451bb9e031edc7394cc65d6b5d64'
+sha256sums=($(curl -sL https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${pkgver}.tar.xz.hashes | grep sha256 | cut -d ' ' -f3)
             '04917e3cd4307d8e31bfb0027a5dce6d086edb10ff8a716024fbb8bb0c7dccf1'
             '0be4bc2e759d2d6136f9baa1d4624aefbababe0cbbd2d1632b76f01654d70524'
             'SKIP')


### PR DESCRIPTION
I've been in the bad habit of locally changing the sha256sum to `SKIP`, so I was hoping we could dynamically fetch it instead. Graciously ripped from AUR's [`chromium-dev`](https://aur.archlinux.org/packages/chromium-dev/).

From a quick glance at the repo, I couldn't determine the significance or relevance of this source: `        chromium-$pkgver.txt::https://chromium.googlesource.com/chromium/src/+/$pkgver?format=TEXT`.  Is there any reason for it? If not could we remove it?
