### PR TITLE
Add kFingerprintingCanvasMeasureTextNoise to switches

### DIFF
--- a/patches/ungoogled-chromium/add-third-party-ungoogled.patch
+++ b/patches/ungoogled-chromium/add-third-party-ungoogled.patch
@@ -15,7 +15,7 @@
 +}
 --- /dev/null
 +++ b/third_party/ungoogled/ungoogled_switches.cc
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,15 @@
 +// Copyright (c) 2018 The ungoogled-chromium Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -27,10 +27,13 @@
 +// Enable fingerprinting deception for getClientRects and getBoundingClientRect
 +const char kFingerprintingClientRectsNoise[] = "fingerprinting-client-rects-noise";
 +
++// Enable fingerprinting deception for measureText
++const char kFingerprintingCanvasMeasureTextNoise[] = "fingerprinting-canvas-measuretext-noise";
++
 +}  // namespace switches
 --- /dev/null
 +++ b/third_party/ungoogled/ungoogled_switches.h
-@@ -0,0 +1,16 @@
+@@ -0,0 +1,17 @@
 +// Copyright (c) 2018 The ungoogled-chromium Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -43,6 +46,7 @@
 +namespace switches {
 +
 +extern const char kFingerprintingClientRectsNoise[];
++extern const char kFingerprintingCanvasMeasureTextNoise[];
 +
 +}
 +


### PR DESCRIPTION
This fixes the following compilation error:
```
./../../chrome/browser/about_flags.cc:1245:42: error: no member named 'kFingerprintingCanvasMeasureTextNoise' in namespace 'switches'
     kOsAll, SINGLE_VALUE_TYPE(switches::kFingerprintingCanvasMeasureTextNoise)},
```