### PR TITLE
Update fingerprinting-flags-client-rects-and-measuretext.patch

### DIFF
--- a/patches/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
+++ b/patches/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
@@ -193,7 +193,7 @@
 +}
 +
 +void WebRuntimeFeatures::EnableFingerprintingCanvasMeasureTextNoise(bool enable) {
-+  RuntimeEnabledFeatures::SetFingerprintingCanvasMeasureTextNoise(enable);
++  RuntimeEnabledFeatures::SetFingerprintingCanvasMeasureTextNoiseEnabled(enable);
 +}
 +
  }  // namespace blink
@@ -279,7 +279,7 @@
 +
 +  // Scale text metrics if enabled
 +  if (RuntimeEnabledFeatures::FingerprintingCanvasMeasureTextNoiseEnabled()) {
-+    textMetrics->Shuffle(canvas()->GetDocument().GetNoiseFactorX())
++    textMetrics->Shuffle(canvas()->GetDocument().GetNoiseFactorX());
 +  }
 +
 +  return textMetrics;


### PR DESCRIPTION
Fixes the following two errors:

```
../../third_party/ffmpeg/../../third_party/blink/renderer/platform/exported/web_runtime_features.cc:564:27: error: no type named 'SetFingerprintingCanvasMeasureTextNoise' in 'blink::RuntimeEnabledFeatures'
  RuntimeEnabledFeatures::SetFingerprintingCanvasMeasureTextNoise(enable);
  ~~~~~~~~~~~~~~~~~~~~~~~~^
```

```
./../../third_party/blink/renderer/modules/canvas/canvas2d/canvas_rendering_context_2d.cc:783:68: error: expected ';' after expression
    textMetrics->Shuffle(canvas()->GetDocument().GetNoiseFactorX())
                                                                   ^
                                                                   ;
```