### PR TITLE
Searx: Use favicon_url property

### DIFF
--- a/patches/ungoogled-chromium/searx.patch
+++ b/patches/ungoogled-chromium/searx.patch
@@ -8,14 +8,14 @@
    // list of search engines on the first run depending on user's country.
    "elements": {
 +    "searx": {
-+	"name": "Searx",
-+	"keyword": "searx.me",
-+	"favicon": "https://searx.me/favicon.ico",
-+	"search_url": "https://searx.me/?q={searchTerms}",
-+	"new_tab_url": "https://searx.me/",
-+	"type": "SEARCH_ENGINE_SEARX",
-+	"id": 12
-+     },
++     "name": "Searx",
++     "keyword": "searx.me",
++     "favicon_url": "https://searx.me/favicon.ico",
++     "search_url": "https://searx.me/?q={searchTerms}",
++     "new_tab_url": "https://searx.me/",
++     "type": "SEARCH_ENGINE_SEARX",
++     "id": 12
++    },
 +
      "duckduckgo": {
        "name": "DuckDuckGo",
@@ -32,7 +32,7 @@
  };
 --- a/components/search_engines/template_url_prepopulate_data.cc
 +++ b/components/search_engines/template_url_prepopulate_data.cc
-@@ -51,548 +51,548 @@ namespace {
+@@ -51,549 +51,549 @@ namespace {
  
  // Default (for countries with no better engine set)
  const PrepopulatedEngine* const engines_default[] = {
@@ -685,8 +685,9 @@
  // A list of all the engines that we know about.
  const PrepopulatedEngine* const kAllEngines[] = {
      // Prepopulated engines:
--    &aol, &ask, &ask_br, &ask_uk, &baidu, &bing, &daum, &duckduckgo, &google, &kvasir,
-+    &aol, &ask, &ask_br, &ask_uk, &baidu, &bing, &daum, &searx, &duckduckgo, &google, &kvasir,
-     &mail_ru, &najdi, &naver, &onet, &seznam, &sogou, &vinden, &virgilio,
+     &aol, &ask, &ask_br, &ask_uk, &baidu, &bing, &daum, &duckduckgo, &google, &kvasir,
+-    &mail_ru, &najdi, &naver, &onet, &seznam, &sogou, &vinden, &virgilio,
++    &mail_ru, &najdi, &naver, &onet, &searx, &seznam, &sogou, &vinden, &virgilio,
      &yahoo, &yahoo_ar, &yahoo_at, &yahoo_au, &yahoo_br, &yahoo_ca, &yahoo_ch,
      &yahoo_cl, &yahoo_co, &yahoo_de, &yahoo_dk, &yahoo_es, &yahoo_fi, &yahoo_fr,
+     &yahoo_gr, &yahoo_hk, &yahoo_id, &yahoo_in, &yahoo_jp, &yahoo_maktoob,


### PR DESCRIPTION
```
FAILED: gen/components/search_engines/prepopulated_engines.cc gen/components/search_engines/prepopulated_engines.h 
/usr/bin/python2 ../../tools/json_to_struct/json_to_struct.py ../../components/search_engines/prepopulated_engines.json --destbase=gen/components/search_engines --namespace=TemplateURLPrepopulateData --schema=../../components/search_engines/prepopulated_engines_schema.json
...
RuntimeError: Mandatory field "favicon_url" omitted in element "searx".
```