### PR TITLE
CFI: Re-enable GN flag use_cfi_icall

### DIFF
--- a/config_bundles/common/patch_order.list
+++ b/config_bundles/common/patch_order.list
@@ -3,6 +3,9 @@ inox-patchset/chromium-clang-compiler-flags.patch
 inox-patchset/chromium-exclude_unwind_tables.patch
 inox-patchset/chromium-skia-harmony.patch
 inox-patchset/chromium-widevine-r2.patch
+inox-patchset/disable-cfi-icall-for-va_stubs.patch
+inox-patchset/fix-cfi-icall-failure-with-use_system_libjpeg-true.patch
+inox-patchset/only-disable-cfi-icall-when-use_system_libjpeg-true.patch
 inox-patchset/0001-fix-building-without-safebrowsing.patch
 inox-patchset/0003-disable-autofill-download-manager.patch
 inox-patchset/0004-disable-google-url-tracker.patch

--- a/config_bundles/linux_portable/gn_flags.map
+++ b/config_bundles/linux_portable/gn_flags.map
@@ -2,7 +2,6 @@ custom_toolchain="//build/toolchain/linux/unbundle:default"
 host_toolchain="//build/toolchain/linux/unbundle:default"
 linux_use_bundled_binutils=false
 optimize_for_size=false
-use_cfi_icall=false
 use_gtk3=true
 use_kerberos=false
 use_lld=true

--- a/config_bundles/linux_rooted/gn_flags.map
+++ b/config_bundles/linux_rooted/gn_flags.map
@@ -7,7 +7,6 @@ link_pulseaudio=true
 linux_use_bundled_binutils=false
 optimize_for_size=false
 use_allocator="none"
-use_cfi_icall=false
 use_cups=true
 use_custom_libcxx=false
 use_gio=true

--- a/patches/inox-patchset/disable-cfi-icall-for-va_stubs.patch
+++ b/patches/inox-patchset/disable-cfi-icall-for-va_stubs.patch
@@ -1,0 +1,28 @@
+From 99db8d62a62610f9aed8225c47dc051b5d61b1a1 Mon Sep 17 00:00:00 2001
+From: Evangelos Foutras <evangelos@foutrelis.com>
+Date: Wed, 05 Sep 2018 22:36:45 +0000
+Subject: [PATCH] Disable cfi-icall for media/gpu/vaapi/va_stubs.cc
+
+Similarly to pulse_stubs.cc, va_stubs.cc contains dlsym() resolved
+functions which trigger cfi-icall failures. The affected builds of
+Chromium do use out-of-tree patches to enable hardware-accelerated
+video decode on Linux where the VA-API driver is installed, but it
+would still be nice to have them work with cfi-icall enabled.
+
+Change-Id: Iefa27f4b95007da23423d17727826adb8825b278
+Reviewed-on: https://chromium-review.googlesource.com/1208830
+Reviewed-by: Peter Collingbourne <pcc@chromium.org>
+Commit-Queue: Peter Collingbourne <pcc@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#589034}
+---
+
+--- a/tools/cfi/blacklist.txt
++++ b/tools/cfi/blacklist.txt
+@@ -146,6 +146,7 @@ fun:*FunctorTraits*
+ 
+ # Calls to auto-generated stubs by generate_stubs.py
+ src:*audio/pulse/pulse_stubs.cc
++src:*media/gpu/vaapi/va_stubs.cc
+ 
+ # Calls to auto-generated stubs by generate_library_loader.py
+ src:*chrome/browser/speech/tts_linux.cc

--- a/patches/inox-patchset/fix-cfi-icall-failure-with-use_system_libjpeg-true.patch
+++ b/patches/inox-patchset/fix-cfi-icall-failure-with-use_system_libjpeg-true.patch
@@ -1,0 +1,45 @@
+From db82db1b609f30d144d45477f55697818bcd363c Mon Sep 17 00:00:00 2001
+From: Vlad Tsyrklevich <vtsyrklevich@chromium.org>
+Date: Tue, 31 Jul 2018 01:03:22 +0000
+Subject: [PATCH] Fix cfi-icall failure with use_system_libjpeg=true
+
+JPEGImageReader::AllocateSampleArray() can call the function pointer
+(*info_.mem->alloc_sarray) which can be set by the systems non-CFI
+enabled libjpeg DSO when chromium is built with use_system_libjpeg=true.
+Disable cfi-icall for that method.
+
+Bug: 866290
+Change-Id: I6d9bbf08c514d6d5f48ad34c3802c63419ed1223
+Reviewed-on: https://chromium-review.googlesource.com/1155927
+Reviewed-by: Kentaro Hara <haraken@chromium.org>
+Commit-Queue: Vlad Tsyrklevich <vtsyrklevich@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#579270}
+---
+ .../renderer/platform/image-decoders/jpeg/jpeg_image_decoder.cc | 2 +-
+ third_party/blink/renderer/platform/wtf/compiler.h              | 2 ++
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+--- a/third_party/blink/renderer/platform/image-decoders/jpeg/jpeg_image_decoder.cc
++++ b/third_party/blink/renderer/platform/image-decoders/jpeg/jpeg_image_decoder.cc
+@@ -643,7 +643,7 @@ class JPEGImageReader final {
+   IntSize UvSize() const { return uv_size_; }
+ 
+  private:
+-  JSAMPARRAY AllocateSampleArray() {
++  NO_SANITIZE_CFI_ICALL JSAMPARRAY AllocateSampleArray() {
+ // Some output color spaces don't need the sample array: don't allocate in that
+ // case.
+ #if defined(TURBO_JPEG_RGB_SWIZZLE)
+--- a/third_party/blink/renderer/platform/wtf/compiler.h
++++ b/third_party/blink/renderer/platform/wtf/compiler.h
+@@ -57,8 +57,10 @@
+ #if defined(__clang__)
+ #define NO_SANITIZE_UNRELATED_CAST \
+   __attribute__((no_sanitize("cfi-unrelated-cast", "vptr")))
++#define NO_SANITIZE_CFI_ICALL __attribute__((no_sanitize("cfi-icall")))
+ #else
+ #define NO_SANITIZE_UNRELATED_CAST
++#define NO_SANITIZE_CFI_ICALL
+ #endif
+ 
+ #endif /* WTF_Compiler_h */

--- a/patches/inox-patchset/only-disable-cfi-icall-when-use_system_libjpeg-true.patch
+++ b/patches/inox-patchset/only-disable-cfi-icall-when-use_system_libjpeg-true.patch
@@ -1,0 +1,29 @@
+From 20f81a066ffdf6bd30fb4b696b8b3e101368e2f6 Mon Sep 17 00:00:00 2001
+From: Vlad Tsyrklevich <vtsyrklevich@chromium.org>
+Date: Tue, 31 Jul 2018 23:21:09 +0000
+Subject: [PATCH] Only disable cfi-icall when use_system_libjpeg=true
+
+Bug: 866290
+Change-Id: Ic5d175b3b854665f50781650406d599d09ee9849
+Reviewed-on: https://chromium-review.googlesource.com/1157136
+Reviewed-by: Kentaro Hara <haraken@chromium.org>
+Commit-Queue: Vlad Tsyrklevich <vtsyrklevich@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#579614}
+---
+ .../platform/image-decoders/jpeg/jpeg_image_decoder.cc       | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- a/third_party/blink/renderer/platform/image-decoders/jpeg/jpeg_image_decoder.cc
++++ b/third_party/blink/renderer/platform/image-decoders/jpeg/jpeg_image_decoder.cc
+@@ -643,7 +643,10 @@ class JPEGImageReader final {
+   IntSize UvSize() const { return uv_size_; }
+ 
+  private:
+-  NO_SANITIZE_CFI_ICALL JSAMPARRAY AllocateSampleArray() {
++#if defined(USE_SYSTEM_LIBJPEG)
++  NO_SANITIZE_CFI_ICALL
++#endif
++  JSAMPARRAY AllocateSampleArray() {
+ // Some output color spaces don't need the sample array: don't allocate in that
+ // case.
+ #if defined(TURBO_JPEG_RGB_SWIZZLE)


### PR DESCRIPTION
With https://chromium-review.googlesource.com/1208830 and a few other patches CFI can be fully enabled and does not cause issue with VA-API anymore.