### PR TITLE
flag-max-connections-per-host.patch: Fix linking

### DIFF
--- a/patches/bromite/flag-max-connections-per-host.patch
+++ b/patches/bromite/flag-max-connections-per-host.patch
@@ -143,3 +143,14 @@ with limited CPU/memory resources and it is disabled by default.
    return g_max_sockets_per_group[pool_type];
  }
  
+--- a/net/BUILD.gn
++++ b/net/BUILD.gn
+@@ -399,6 +399,8 @@ component("net") {
+ 
+   if (!is_nacl) {
+     sources += [
++      "../components/network_session_configurator/common/network_switches.cc",
++      "../components/network_session_configurator/common/network_switches.h",
+       "android/cellular_signal_strength.cc",
+       "android/cellular_signal_strength.h",
+       "android/cert_verify_result_android.cc",


### PR DESCRIPTION
Fixes an error during linking
```
[324/1491] LINK ./chromedriver
FAILED: chromedriver 
/usr/bin/python2 "../../build/toolchain/gcc_link_wrapper.py" ...
/usr/bin/ld.lld: error: undefined symbol: switches::kMaxConnectionsPerHost
>>> referenced by client_socket_pool_manager.cc
>>>               thinlto-cache/llvmcache-85C4525DA98E61B64827CE7679DD33C92882EC46:(net::ClientSocketPoolManager::max_sockets_per_group(net::HttpNetworkSession::SocketPoolType))
```