### PR TITLE
windows: fix build.py

### DIFF
--- a/packaging/windows/build.py
+++ b/packaging/windows/build.py
@@ -31,6 +31,10 @@ from buildkit.common import ENCODING, SEVENZIP_USE_REGISTRY, ExtractorEnum, get_
 sys.path.pop(0)
 
 
+def _path_quote_spaces(path):
+    return '"' + path + '"' if ' ' in path else path
+
+
 def _get_vcvars_path(name='64'):
     """
     Returns the path to the corresponding vcvars*.bat path
@@ -56,9 +60,10 @@ def _run_build_process(*args, **kwargs):
     Runs the subprocess with the correct environment variables for building
     """
     # Add call to set VC variables
-    cmd_input = [' '.join(('call', shlex.quote(str(_get_vcvars_path()))))]
-    cmd_input.append(' '.join(map(shlex.quote, args)))
-    subprocess.run('cmd.exe', input='\n'.join(cmd_input), check=True, **kwargs)
+    cmd_input = [' '.join(('call', _path_quote_spaces(str(_get_vcvars_path())), '>nul'))]
+    cmd_input.append(' '.join(_path_quote_spaces(arg) for arg in args))
+    cmd_input.append('exit\n')
+    subprocess.run(('cmd.exe', '/k'), input='\n'.join(cmd_input), check=True, encoding=ENCODING, **kwargs)
 
 
 def _test_python2(error_exit):


### PR DESCRIPTION
Fix TypeError

    Traceback (most recent call last):
      File "ungoogled_packaging\build.py", line 186, in <module>
        main()
      File "ungoogled_packaging\build.py", line 174, in main
        'out\\Default\\gn.exe', '--build-path', 'out\\gn_build')
      File "ungoogled_packaging\build.py", line 61, in _run_build_process
        subprocess.run('cmd.exe', input='\n'.join(cmd_input), check=True, **kwargs)
      File "C:\Users\TEST\AppData\Local\Programs\Python\Python37\lib\subprocess.py", line 455, in run
        stdout, stderr = process.communicate(input, timeout=timeout)
      File "C:\Users\TEST\AppData\Local\Programs\Python\Python37\lib\subprocess.py", line 905, in communicate
        self._stdin_write(input)
      File "C:\Users\TEST\AppData\Local\Programs\Python\Python37\lib\subprocess.py", line 854, in _stdin_write
        self.stdin.write(input)
    TypeError: a bytes-like object is required, not 'str'

Fix cmd input string

    E:\work\github\shiromichi\ungoogled-chromium\build\src>call 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat'
    The filename, directory name, or volume label syntax is incorrect.

Fix displaying "More?"

     E:\work\github\shiromichi\ungoogled-chromium\build\src>call 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat'
     The filename, directory name, or volume label syntax is incorrect.
     
     E:\work\github\shiromichi\ungoogled-chromium\build\src>More? Traceback (most recent call last):
       File "E:\work\github\shiromichi\ungoogled-chromium\build\src\ungoogled_packaging\build.py", line 186, in <module>
         main()
       File "E:\work\github\shiromichi\ungoogled-chromium\build\src\ungoogled_packaging\build.py", line 175, in main

Hide "cmd.exe" startup message

     Microsoft Windows [Version 10.0.15063]
     (c) 2017 Microsoft Corporation. All rights reserved.
     
     E:\work\github\shiromichi\ungoogled-chromium\build\src>call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"


Hide "vcvars64.bat" echo

     E:\work\github\shiromichi\ungoogled-chromium\build\src>call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
         **********************************************************************
         ** Visual Studio 2017 Developer Command Prompt v15.8.2
         ** Copyright (c) 2017 Microsoft Corporation
         **********************************************************************
         [vcvarsall.bat] Environment initialized for: 'x64'

