### PR TITLE
dont throw error when folder exists

### DIFF
--- a/packaging/macos/build.sh.ungoogin
+++ b/packaging/macos/build.sh.ungoogin
@@ -22,7 +22,7 @@ mkdir out/Default
 DOWNLOAD_CACHE="$packaging_dir/../../download_cache"
 
 pushd ungoogled_packaging
-mkdir "$DOWNLOAD_CACHE" 
+mkdir -p "$DOWNLOAD_CACHE" 
 python3 -m buildkit downloads retrieve -b config_bundles/macos -c "$DOWNLOAD_CACHE"
 python3 -m buildkit downloads unpack -b config_bundles/macos -c "$DOWNLOAD_CACHE" ../
 python3 -m buildkit prune -b config_bundles/macos ../


### PR DESCRIPTION
this change skips re-download same archive file from remote location..
this will trim approx 600mb file download time for the next build..
