### PR TITLE
windows: Fix ninja: error: unknown target 'gn'

### DIFF
--- a/patches/ungoogled-chromium/windows/windows-fix-building-gn.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-building-gn.patch
@@ -1,6 +1,29 @@
 # Fix building GN on Windows
 # Author: shiromichi on GitHub
+# Please apply this patch after patches/ungoogled-chromium/gn-bootstrap-remove-gn-gen.patch
 
+--- a/tools/gn/bootstrap/bootstrap.py
++++ b/tools/gn/bootstrap/bootstrap.py
+@@ -61,7 +61,7 @@ def main(argv):
+   else:
+     build_rel = os.path.join('out', 'Release')
+   out_dir = os.path.join(SRC_ROOT, build_rel)
+-  gn_path = options.output or os.path.join(out_dir, 'gn')
++  gn_path = options.output or os.path.join(out_dir, 'gn.exe')
+   gn_build_dir = os.path.join(out_dir, 'gn_build')
+ 
+   cmd = [
+@@ -79,8 +79,8 @@ def main(argv):
+   shutil.copy2(
+       os.path.join(BOOTSTRAP_DIR, 'last_commit_position.h'), gn_build_dir)
+   subprocess.check_call(
+-      ['ninja', '-C', gn_build_dir, 'gn', '-w', 'dupbuild=err'])
+-  shutil.copy2(os.path.join(gn_build_dir, 'gn'), gn_path)
++      ['ninja', '-C', gn_build_dir, 'gn.exe', '-w', 'dupbuild=err'])
++  shutil.copy2(os.path.join(gn_build_dir, 'gn.exe'), gn_path)
+ 
+ 
+ if __name__ == '__main__':
 --- a/tools/gn/build/build_win.ninja.template
 +++ b/tools/gn/build/build_win.ninja.template
 @@ -1,12 +1,12 @@


### PR DESCRIPTION
Fix the following problem

    E:\work\github\Eloston\ungoogled-chromium\build\src>"C:\Python27\python.EXE" "tools\gn\bootstrap\bootstrap.py" "-o" "out\Default\gn.exe"
    ninja: Entering directory `E:\work\github\Eloston\ungoogled-chromium\build\src\out\Release\gn_build'
    ninja: error: unknown target 'gn'
    Traceback (most recent call last):
      File "tools\gn\bootstrap\bootstrap.py", line 92, in <module>
        sys.exit(main(sys.argv[1:]))
      File "tools\gn\bootstrap\bootstrap.py", line 87, in main
        ['ninja', '-C', gn_build_dir, 'gn', '-w', 'dupbuild=err'])
      File "C:\Python27\lib\subprocess.py", line 190, in check_call
        raise CalledProcessError(retcode, cmd)
    subprocess.CalledProcessError: Command '['ninja', '-C', 'E:\\work\\github\\Eloston\\ungoogled-chromium\\build\\src\\out\\Release\\gn_build', 'gn', '-w', 'dupbuild=err']' returned non-zero exit status 1

    E:\work\github\Eloston\ungoogled-chromium\build\src>exit
    Traceback (most recent call last):
      File "ungoogled_package\build.py", line 186, in <module>
        main()
      File "ungoogled_package\build.py", line 175, in main
        shutil.which('python'), 'tools\\gn\\bootstrap\\bootstrap.py', '-o', 'out\\Default\\gn.exe')
      File "ungoogled_package\build.py", line 65, in _run_build_process
        **kwargs)
      File "C:\Users\TEST\AppData\Local\Programs\Python\Python37\lib\subprocess.py", line 468, in run
        output=stdout, stderr=stderr)
    subprocess.CalledProcessError: Command '('cmd.exe', '/k')' returned non-zero exit status 1.
