### PR TITLE
Add show-avatar-button flag

### DIFF
--- a/config_bundles/common/patch_order.list
+++ b/config_bundles/common/patch_order.list
@@ -109,6 +109,7 @@ ungoogled-chromium/searx.patch
 ungoogled-chromium/remove-third-party-analytics.patch
 ungoogled-chromium/gn-bootstrap-remove-gn-gen.patch
 ungoogled-chromium/disable-webgl-renderer-info.patch
+ungoogled-chromium/add-flag-to-show-avatar-button.patch
 
 bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 bromite/flag-max-connections-per-host.patch

--- a/patches/ungoogled-chromium/add-flag-to-show-avatar-button.patch
+++ b/patches/ungoogled-chromium/add-flag-to-show-avatar-button.patch
@@ -79,16 +79,13 @@
    // This should never be called in incognito mode.
    DCHECK(browser_view->IsRegularOrGuestSession());
    ProfileAttributesEntry* unused;
-@@ -42,7 +48,13 @@ void AvatarButtonManager::Update(AvatarB
+@@ -42,7 +48,10 @@ void AvatarButtonManager::Update(AvatarB
              ->GetProfileAttributesStorage()
              .GetProfileAttributesWithPath(profile->GetPath(), &unused)) ||
         // Desktop guest shows the avatar button.
 -       browser_view->IsIncognito())) {
-+       browser_view->IsIncognito() ||
++       browser_view->IsIncognito()) &&
 +       // Override according to show-avatar-button value.
-+       (flag_value == "always") ||
-+       (flag_value == "incognito-and-guest" && in_incognito_or_guest_mode)
-+       ) &&
 +      !(flag_value == "incognito-and-guest" && !in_incognito_or_guest_mode) &&
 +      !(flag_value == "never")) {
      if (!avatar_button_) {

--- a/patches/ungoogled-chromium/add-flag-to-show-avatar-button.patch
+++ b/patches/ungoogled-chromium/add-flag-to-show-avatar-button.patch
@@ -1,0 +1,96 @@
+--- a/chrome/browser/about_flags.cc
++++ b/chrome/browser/about_flags.cc
+@@ -208,6 +208,19 @@ const FeatureEntry::Choice kExtensionHan
+      "always-prompt-for-install"},
+ };
+ 
++const FeatureEntry::Choice kShowAvatarButtonChoices[] = {
++    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
++    {"Always",
++     "show-avatar-button",
++     "always"},
++    {"Incognito and Guest",
++     "show-avatar-button",
++     "incognito-and-guest"},
++    {"Never",
++     "show-avatar-button",
++     "never"}
++};
++
+ const FeatureEntry::Choice kTouchEventFeatureDetectionChoices[] = {
+     {flags_ui::kGenericExperimentChoiceAutomatic, "", ""},
+     {flags_ui::kGenericExperimentChoiceEnabled,
+@@ -4149,6 +4162,11 @@ const FeatureEntry kFeatureEntries[] = {
+      flag_descriptions::kEnableBloatedRendererDetectionDescription, kOsAll,
+      FEATURE_VALUE_TYPE(features::kBloatedRendererDetection)},
+ 
++    {"show-avatar-button",
++     "Show avatar button",
++     "Show avatar button in the browser toolbar", kOsDesktop,
++     MULTI_VALUE_TYPE(kShowAvatarButtonChoices)},
++
+     // NOTE: Adding a new flag requires adding a corresponding entry to enum
+     // "LoginCustomFlags" in tools/metrics/histograms/enums.xml. See "Flag
+     // Histograms" in tools/metrics/histograms/README.md (run the
+--- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
++++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
+@@ -206,12 +206,27 @@ void ToolbarView::Init() {
+       new BrowserActionsContainer(browser_, main_container, this);
+ 
+   if (ui::MaterialDesignController::IsRefreshUi()) {
++    const base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
++    const std::string flag_value = command_line.GetSwitchValueASCII("show-avatar-button");
++
++    bool in_incognito_or_guest_mode = browser_->profile()->IsOffTheRecord() ||
++                                      browser_->profile()->IsGuestSession();
++
++    // Default behavior.
+     bool show_avatar_toolbar_button = true;
+ #if defined(OS_CHROMEOS)
+     // ChromeOS only badges Incognito and Guest icons in the browser window.
+-    show_avatar_toolbar_button = browser_->profile()->IsOffTheRecord() ||
+-                                 browser_->profile()->IsGuestSession();
++    show_avatar_toolbar_button = in_incognito_or_guest_mode;
+ #endif  // !defined(OS_CHROMEOS)
++
++    // Override according to show-avatar-button value.
++    if (flag_value == "always")
++      show_avatar_toolbar_button = true;
++    else if (flag_value == "incognito-and-guest")
++      show_avatar_toolbar_button = in_incognito_or_guest_mode;
++    else if (flag_value == "never")
++      show_avatar_toolbar_button = false;
++
+     if (show_avatar_toolbar_button)
+       avatar_ = new AvatarToolbarButton(browser_);
+   }
+--- a/chrome/browser/ui/views/frame/avatar_button_manager.cc
++++ b/chrome/browser/ui/views/frame/avatar_button_manager.cc
+@@ -31,6 +31,12 @@ void AvatarButtonManager::Update(AvatarB
+   BrowserFrame* frame = frame_view_->frame();
+   Profile* profile = browser_view->browser()->profile();
+ 
++  const base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
++  const std::string flag_value = command_line.GetSwitchValueASCII("show-avatar-button");
++
++  bool in_incognito_or_guest_mode = profile->IsOffTheRecord() ||
++                                    profile->IsGuestSession();
++
+   // This should never be called in incognito mode.
+   DCHECK(browser_view->IsRegularOrGuestSession());
+   ProfileAttributesEntry* unused;
+@@ -42,7 +48,13 @@ void AvatarButtonManager::Update(AvatarB
+             ->GetProfileAttributesStorage()
+             .GetProfileAttributesWithPath(profile->GetPath(), &unused)) ||
+        // Desktop guest shows the avatar button.
+-       browser_view->IsIncognito())) {
++       browser_view->IsIncognito() ||
++       // Override according to show-avatar-button value.
++       (flag_value == "always") ||
++       (flag_value == "incognito-and-guest" && in_incognito_or_guest_mode)
++       ) &&
++      !(flag_value == "incognito-and-guest" && !in_incognito_or_guest_mode) &&
++      !(flag_value == "never")) {
+     if (!avatar_button_) {
+       avatar_button_ = new AvatarButton(this, style, profile, this);
+       avatar_button_->set_id(VIEW_ID_AVATAR_BUTTON);


### PR DESCRIPTION
This adds the ability to hide avatar toolbar button. The button is enabled by default. #259 