### PR TITLE
Portability on Windows

### DIFF
--- a/config_bundles/windows/patch_order.list
+++ b/config_bundles/windows/patch_order.list
@@ -6,3 +6,5 @@ ungoogled-chromium/windows/windows-disable-rcpy.patch
 ungoogled-chromium/windows/windows-fix-building-without-safebrowsing.patch
 ungoogled-chromium/windows/windows-fix-enum-conflict.patch
 ungoogled-chromium/windows/windows-fix-building-gn.patch
+ungoogled-chromium/windows/windows-disable-encryption.patch
+ungoogled-chromium/windows/windows-disable-machine-id.patch

--- a/patches/ungoogled-chromium/windows/windows-disable-encryption.patch
+++ b/patches/ungoogled-chromium/windows/windows-disable-encryption.patch
@@ -1,0 +1,37 @@
+# Disable encryption of cookies, passwords, settings...
+# WARNING! Use ONLY if your hard drive is encrypted or if you know what you are doing.
+# See https://github.com/Eloston/ungoogled-chromium/issues/444
+
+--- a/components/os_crypt/os_crypt_win.cc
++++ b/components/os_crypt/os_crypt_win.cc
+@@ -6,6 +6,7 @@
+ 
+ #include <windows.h>
+ 
++#include "base/command_line.h"
+ #include "base/strings/utf_string_conversions.h"
+ #include "crypto/wincrypt_shim.h"
+ 
+@@ -26,6 +27,10 @@ bool OSCrypt::DecryptString16(const std::string& ciphertext,
+ 
+ bool OSCrypt::EncryptString(const std::string& plaintext,
+                             std::string* ciphertext) {
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("disable-encryption")) {
++    *ciphertext = plaintext;
++    return true;
++  }
+   DATA_BLOB input;
+   input.pbData = const_cast<BYTE*>(
+       reinterpret_cast<const BYTE*>(plaintext.data()));
+@@ -49,6 +54,11 @@ bool OSCrypt::EncryptString(const std::string& plaintext,
+ 
+ bool OSCrypt::DecryptString(const std::string& ciphertext,
+                             std::string* plaintext) {
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("disable-encryption")) {
++    *plaintext = ciphertext;
++    return true;
++  }
++
+   DATA_BLOB input;
+   input.pbData = const_cast<BYTE*>(
+       reinterpret_cast<const BYTE*>(ciphertext.data()));

--- a/patches/ungoogled-chromium/windows/windows-disable-machine-id.patch
+++ b/patches/ungoogled-chromium/windows/windows-disable-machine-id.patch
@@ -1,0 +1,53 @@
+# Disable machine ID generation on Windows.
+# See https://github.com/Eloston/ungoogled-chromium/issues/444
+
+--- a/services/preferences/tracked/device_id_win.cc
++++ b/services/preferences/tracked/device_id_win.cc
+@@ -10,11 +10,15 @@
+
+ #include <memory>
+
++#include "base/command_line.h"
+ #include "base/logging.h"
+ #include "base/macros.h"
+
+ MachineIdStatus GetDeterministicMachineSpecificId(std::string* machine_id) {
+   DCHECK(machine_id);
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("disable-machine-id")) {
++    return MachineIdStatus::NOT_IMPLEMENTED;
++  }
+
+   wchar_t computer_name[MAX_COMPUTERNAME_LENGTH + 1] = {};
+   DWORD computer_name_size = arraysize(computer_name);
+--- a/components/metrics/machine_id_provider_win.cc
++++ b/components/metrics/machine_id_provider_win.cc
+@@ -9,6 +9,7 @@
+ #include <winioctl.h>
+ 
+ #include "base/base_paths.h"
++#include "base/command_line.h"
+ #include "base/files/file_path.h"
+ #include "base/path_service.h"
+ #include "base/threading/scoped_blocking_call.h"
+@@ -18,6 +19,9 @@ namespace metrics {
+ 
+ // static
+ bool MachineIdProvider::HasId() {
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("disable-machine-id")) {
++    return false;
++  }
+   return true;
+ }
+ 
+@@ -25,6 +29,11 @@ bool MachineIdProvider::HasId() {
+ // is running from.
+ // static
+ std::string MachineIdProvider::GetMachineId() {
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("disable-machine-id")) {
++    NOTREACHED();
++    return std::string();
++  }
++
+   base::ScopedBlockingCall scoped_blocking_call(base::BlockingType::MAY_BLOCK);
+ 
+   // Use the program's path to get the drive used for the machine id. This means

--- a/patches/ungoogled-chromium/windows/windows-disable-machine-id.patch
+++ b/patches/ungoogled-chromium/windows/windows-disable-machine-id.patch
@@ -39,12 +39,11 @@
    return true;
  }
  
-@@ -25,6 +29,11 @@ bool MachineIdProvider::HasId() {
+@@ -25,6 +29,10 @@ bool MachineIdProvider::HasId() {
  // is running from.
  // static
  std::string MachineIdProvider::GetMachineId() {
 +  if (base::CommandLine::ForCurrentProcess()->HasSwitch("disable-machine-id")) {
-+    NOTREACHED();
 +    return std::string();
 +  }
 +


### PR DESCRIPTION
Closes #444

## About

The purpose of this PR is to allow the portability of Chromium on Windows with the addition of two new switches :

* `disable-machine-id` : Allows disabling the machine ID generation on Windows.
* `disable-encryption` : Allows disabling encryption of cookies, passwords, settings. Should be ONLY used if your hard drive is encrypted or if you know what you are doing :upside_down_face:

This allows the portability of everything, except certificates.

Related threads :

* portapps/brave-portable#4
* brave/brave-browser#694
* brave/brave-core#795

## Test

### disable-machine-id

* Launch chormium with switch `--disable-machine-id`
* Install an extension
* Close chormium and copy data to a second computer
* Launch chormium on the second computer
* The extension must be ok

### disable-encryption

* Launch chormium with switch `--disable-encryption`
* Login to a known website with credentials and save them (will add unencrypted cookies and passwords to database)
* Close chormium and copy data to a second computer
* Launch chormium on the second computer
* You must be still logged in on the website and credentials must be kept intact in the database

### use both switches

* Previous and following settings must be ok too :
  * Default search engine
  * Homepage
  * Startup pages
  * Pinned tabs