### PR TITLE
Sysroot patch, closes #590

### DIFF
--- a/config_bundles/common/patch_order.list
+++ b/config_bundles/common/patch_order.list
@@ -112,6 +112,7 @@ ungoogled-chromium/remove-third-party-analytics.patch
 ungoogled-chromium/gn-bootstrap-remove-gn-gen.patch
 ungoogled-chromium/disable-webgl-renderer-info.patch
 ungoogled-chromium/add-flag-to-show-avatar-button.patch
+ungoogled-chromium/no-such-option-no-sysroot.patch
 
 bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 bromite/flag-max-connections-per-host.patch

--- a/patches/ungoogled-chromium/no-such-option-no-sysroot.patch
+++ b/patches/ungoogled-chromium/no-such-option-no-sysroot.patch
@@ -1,0 +1,24 @@
+# Removes the --no-sysroot option, not a valid option anymore
+
+--- a/tools/gn/bootstrap/bootstrap.py
++++ b/tools/gn/bootstrap/bootstrap.py
+@@ -46,10 +46,6 @@
+       '--build-path',
+       help='The directory in which to build gn, '
+       'relative to the src directory. (eg. out/Release)')
+-  parser.add_option(
+-      '--with-sysroot',
+-      action='store_true',
+-      help='Download and build with the Debian sysroot.')
+   parser.add_option('-v', '--verbose', help='ignored')
+   parser.add_option(
+       '--skip-generate-buildfiles',
+@@ -76,8 +72,6 @@
+       '--no-last-commit-position',
+       '--out-path=' + gn_build_dir,
+   ]
+-  if not options.with_sysroot:
+-    cmd.append('--no-sysroot')
+   if options.debug:
+     cmd.append('--debug')
+   subprocess.check_call(cmd)


### PR DESCRIPTION
Temporary fix needed until [4849d9a19f700961e2c25b642bdaaa6514040e60](https://chromium.googlesource.com/chromium/src.git/+/4849d9a19f700961e2c25b642bdaaa6514040e60) gets included in a supported tagged release.

See #590 