### PR TITLE
disable-google-host-detection.patch: update for 70.0.3538.110

### DIFF
--- a/patches/ungoogled-chromium/disable-google-host-detection.patch
+++ b/patches/ungoogled-chromium/disable-google-host-detection.patch
@@ -459,7 +459,7 @@
  bool IsGoogleHostname(const GURL& url) {
 --- a/chrome/common/google_url_loader_throttle.cc
 +++ b/chrome/common/google_url_loader_throttle.cc
-@@ -33,8 +33,6 @@ void GoogleURLLoaderThrottle::WillStartR
+@@ -33,8 +33,6 @@ void GoogleURLLoaderThrottle::WillStartRequest(
    if (!is_off_the_record_ &&
        variations::ShouldAppendVariationHeaders(request->url) &&
        !variation_ids_header_.empty()) {
@@ -468,15 +468,16 @@
    }
  
    if (force_safe_search_) {
-@@ -66,8 +64,6 @@ void GoogleURLLoaderThrottle::WillRedire
+@@ -66,9 +64,6 @@ void GoogleURLLoaderThrottle::WillRedirectRequest(
      bool* /* defer */,
      std::vector<std::string>* to_be_removed_headers,
-     net::HttpRequestHeaders* /* modified_headers */) {
+     net::HttpRequestHeaders* modified_headers) {
 -  if (!variations::ShouldAppendVariationHeaders(redirect_info.new_url))
 -    to_be_removed_headers->push_back(variations::kClientDataHeader);
- }
- 
- #if BUILDFLAG(ENABLE_EXTENSIONS)
+-
+   if (youtube_restrict_ > safe_search_util::YOUTUBE_RESTRICT_OFF &&
+       youtube_restrict_ < safe_search_util::YOUTUBE_RESTRICT_COUNT) {
+     safe_search_util::ForceYouTubeRestrict(
 --- a/chrome/renderer/chrome_content_renderer_client.cc
 +++ b/chrome/renderer/chrome_content_renderer_client.cc
 @@ -1628,7 +1628,7 @@ void ChromeContentRendererClient::WillDe


### PR DESCRIPTION
The original `google_url_loader_throttle.cc` was changed by this [commit](https://chromium.googlesource.com/chromium/src.git/+/6de84dcfeabbb2a503f47b30b68fe649aa743953%5E%21/#F3).