### PR TITLE
Update Windows patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ __pycache__/
 .DS_Store
 .tm_properties
 
-# Ignore optional build directory
+# Ignore optional build / cache directory
 /build
+/downloads_cache

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ __pycache__/
 
 # Ignore optional build / cache directory
 /build
-/downloads_cache

--- a/buildkit/extraction.py
+++ b/buildkit/extraction.py
@@ -67,8 +67,6 @@ def _process_relative_to(unpack_root, relative_to):
         raise BuildkitAbort()
     for src_path in relative_root.iterdir():
         dest_path = unpack_root / src_path.name
-        if os.path.exists(dest_path):
-            os.remove(dest_path)
         src_path.rename(dest_path)
     relative_root.rmdir()
 
@@ -92,8 +90,6 @@ def prune_dir(unpack_root, ignore_files):
 
 def _extract_tar_with_7z(binary, archive_path, output_dir, relative_to):
     get_logger().debug('Using 7-zip extractor')
-    if os.path.exists(output_dir / relative_to):
-        shutil.rmtree(output_dir / relative_to)
     if not relative_to is None and (output_dir / relative_to).exists():
         get_logger().error('Temporary unpacking directory already exists: %s',
                            output_dir / relative_to)

--- a/buildkit/extraction.py
+++ b/buildkit/extraction.py
@@ -67,6 +67,8 @@ def _process_relative_to(unpack_root, relative_to):
         raise BuildkitAbort()
     for src_path in relative_root.iterdir():
         dest_path = unpack_root / src_path.name
+        if os.path.exists(dest_path):
+            os.remove(dest_path)
         src_path.rename(dest_path)
     relative_root.rmdir()
 
@@ -90,6 +92,8 @@ def prune_dir(unpack_root, ignore_files):
 
 def _extract_tar_with_7z(binary, archive_path, output_dir, relative_to):
     get_logger().debug('Using 7-zip extractor')
+    if os.path.exists(output_dir / relative_to):
+        shutil.rmtree(output_dir / relative_to)
     if not relative_to is None and (output_dir / relative_to).exists():
         get_logger().error('Temporary unpacking directory already exists: %s',
                            output_dir / relative_to)

--- a/patches/ungoogled-chromium/windows/windows-disable-reorder-fix-linking.patch
+++ b/patches/ungoogled-chromium/windows/windows-disable-reorder-fix-linking.patch
@@ -2,10 +2,10 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -49,35 +49,6 @@ if (enable_resource_whitelist_generation
+@@ -49,35 +49,6 @@ if (enable_resource_whitelist_generation) {
    chrome_resource_whitelist = "$target_gen_dir/chrome_resource_whitelist.txt"
  }
- 
+
 -if (is_win) {
 -  action("reorder_imports") {
 -    script = "//build/win/reorder-imports.py"
@@ -48,9 +48,9 @@
      if (use_aura && (is_win || is_linux)) {
        data_deps += [ "//chrome/app:service_manifests" ]
      }
-@@ -333,11 +301,7 @@ if (!is_android && !is_mac) {
+@@ -339,11 +307,7 @@ if (!is_android && !is_mac) {
    }
- 
+
    chrome_binary("chrome_initial") {
 -    if (is_win) {
 -      output_name = "initialexe/chrome"
@@ -58,26 +58,15 @@
 -      output_name = "chrome"
 -    }
 +    output_name = "chrome"
- 
+
      sources = []
      if (!is_win && use_aura) {
 --- a/tools/perf/chrome_telemetry_build/BUILD.gn
 +++ b/tools/perf/chrome_telemetry_build/BUILD.gn
-@@ -40,10 +40,6 @@ group("telemetry_chrome_test") {
-     "//components/crash/content/tools/generate_breakpad_symbols.py",
-   ]
- 
--  if (is_win) {
--    data_deps += [ "//chrome:reorder_imports" ]
--  }
--
-   if (is_linux) {
-     data_deps += [ "//third_party/breakpad:dump_syms($host_toolchain)" ]
+@@ -32,10 +32,6 @@ group("telemetry_chrome_test") {
+     data_deps += [ "//chrome" ]
    }
-@@ -108,10 +104,6 @@ group("telemetry_chrome_test_without_chr
-     "//components/crash/content/tools/generate_breakpad_symbols.py",
-   ]
- 
+
 -  if (is_win) {
 -    data_deps += [ "//chrome:reorder_imports" ]
 -  }
@@ -87,7 +76,7 @@
    }
 --- a/chrome/test/chromedriver/BUILD.gn
 +++ b/chrome/test/chromedriver/BUILD.gn
-@@ -348,11 +348,6 @@ python_library("chromedriver_py_tests")
+@@ -357,11 +357,6 @@ python_library("chromedriver_py_tests") {
    if (is_component_build && is_mac) {
      data_deps += [ "//chrome:chrome_framework" ]
    }
@@ -97,5 +86,5 @@
 -    data_deps += [ "//chrome:reorder_imports" ]
 -  }
  }
- 
- test("chromedriver_unittests") {
+
+ python_library("chromedriver_replay_unittests") {

--- a/patches/ungoogled-chromium/windows/windows-fix-building-without-safebrowsing.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-building-without-safebrowsing.patch
@@ -3,7 +3,7 @@
 
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -308,8 +308,6 @@ jumbo_split_static_library("browser") {
+@@ -307,8 +307,6 @@ jumbo_split_static_library("browser") {
      "component_updater/subresource_filter_component_installer.h",
      "component_updater/supervised_user_whitelist_installer.cc",
      "component_updater/supervised_user_whitelist_installer.h",
@@ -12,9 +12,9 @@
      "conflicts/enumerate_input_method_editors_win.cc",
      "conflicts/enumerate_input_method_editors_win.h",
      "conflicts/enumerate_shell_extensions_win.cc",
-@@ -1674,11 +1672,11 @@ jumbo_split_static_library("browser") {
-     "//chrome/browser/net:probe_message_proto",
+@@ -1706,11 +1704,11 @@ jumbo_split_static_library("browser") {
      "//chrome/browser/profiling_host",
+     "//chrome/browser/push_messaging:budget_proto",
      "//chrome/browser/resource_coordinator:mojo_bindings",
 -    "//chrome/browser/safe_browsing",
      "//chrome/browser/ssl:proto",
@@ -25,40 +25,27 @@
      "//chrome/installer/util:with_no_strings",
      "//components/about_handler",
      "//components/app_modal",
---- a/chrome/browser/extensions/BUILD.gn
-+++ b/chrome/browser/extensions/BUILD.gn
-@@ -800,7 +800,6 @@ jumbo_static_library("extensions") {
-     "//chrome/browser/media/router",
-     "//chrome/browser/media/router/discovery",
-     "//chrome/browser/resource_coordinator:mojo_bindings",
--    "//chrome/browser/safe_browsing",
-     "//chrome/browser/web_applications/extensions",
-     "//chrome/common",
-     "//chrome/common/extensions:mojo_bindings",
---- a/chrome/browser/ui/BUILD.gn
-+++ b/chrome/browser/ui/BUILD.gn
-@@ -910,7 +910,6 @@ split_static_library("ui") {
-     "//chrome/browser/engagement:mojo_bindings",
-     "//chrome/browser/media:mojo_bindings",
-     "//chrome/browser/profiling_host",
--    "//chrome/browser/safe_browsing",
-     "//chrome/browser/ssl:proto",
-     "//chrome/browser/ui/webui/bluetooth_internals",
-     "//chrome/browser/ui/webui/interventions_internals:mojo_bindings",
-@@ -2647,10 +2646,6 @@ split_static_library("ui") {
-       "network_profile_bubble.h",
-       "startup/default_browser_prompt_win.cc",
-       "views/certificate_viewer_win.cc",
--      "views/chrome_cleaner_dialog_win.cc",
--      "views/chrome_cleaner_dialog_win.h",
--      "views/chrome_cleaner_reboot_dialog_win.cc",
--      "views/chrome_cleaner_reboot_dialog_win.h",
-       "views/color_chooser_dialog.cc",
-       "views/color_chooser_dialog.h",
-       "views/color_chooser_win.cc",
+--- a/chrome/browser/chrome_browser_main.cc
++++ b/chrome/browser/chrome_browser_main.cc
+@@ -239,7 +239,6 @@
+ #include "base/trace_event/trace_event_etw_export_win.h"
+ #include "base/win/win_util.h"
+ #include "chrome/browser/chrome_browser_main_win.h"
+-#include "chrome/browser/component_updater/sw_reporter_installer_win.h"
+ #if defined(GOOGLE_CHROME_BUILD)
+ #include "chrome/browser/component_updater/third_party_module_list_component_installer_win.h"
+ #endif  // defined(GOOGLE_CHROME_BUILD)
+@@ -601,7 +600,6 @@ void RegisterComponentsForUpdate(PrefService* profile_prefs) {
+   // on chromium build bots, it is always registered here and
+   // RegisterSwReporterComponent() has support for running only in official
+   // builds or tests.
+-  RegisterSwReporterComponent(cus);
+ #if defined(GOOGLE_CHROME_BUILD)
+   RegisterThirdPartyModuleListComponent(cus);
+ #endif  // defined(GOOGLE_CHROME_BUILD)
 --- a/chrome/browser/chrome_browser_main_win.cc
 +++ b/chrome/browser/chrome_browser_main_win.cc
-@@ -44,9 +44,6 @@
+@@ -43,9 +43,6 @@
  #include "chrome/browser/memory/swap_thrashing_monitor.h"
  #include "chrome/browser/profiles/profile_manager.h"
  #include "chrome/browser/profiles/profile_shortcut_manager.h"
@@ -68,10 +55,10 @@
  #include "chrome/browser/ui/simple_message_box.h"
  #include "chrome/browser/ui/uninstall_browser_prompt.h"
  #include "chrome/browser/win/browser_util.h"
-@@ -398,16 +395,6 @@ void ShowCloseBrowserFirstMessageBox() {
+@@ -397,16 +394,6 @@ void ShowCloseBrowserFirstMessageBox() {
        l10n_util::GetStringUTF16(IDS_UNINSTALL_CLOSE_APP));
  }
- 
+
 -void MaybePostSettingsResetPrompt() {
 -  if (base::FeatureList::IsEnabled(safe_browsing::kSettingsResetPrompt)) {
 -    content::BrowserThread::PostAfterStartupTask(
@@ -83,12 +70,12 @@
 -}
 -
  }  // namespace
- 
+
  int DoUninstallTasks(bool chrome_still_running) {
-@@ -564,23 +551,6 @@ void ChromeBrowserMainPartsWin::PostBrow
- 
+@@ -555,23 +542,6 @@ void ChromeBrowserMainPartsWin::PostBrowserStart() {
+
    InitializeChromeElf();
- 
+
 -  // Reset settings for the current profile if it's tagged to be reset after a
 -  // complete run of the Chrome Cleanup tool. If post-cleanup settings reset is
 -  // enabled, we delay checks for settings reset prompt until the scheduled
@@ -109,22 +96,175 @@
    // Record UMA data about whether the fault-tolerant heap is enabled.
    // Use a delayed task to minimize the impact on startup time.
    content::BrowserThread::PostDelayedTask(
+--- a/chrome/browser/extensions/BUILD.gn
++++ b/chrome/browser/extensions/BUILD.gn
+@@ -808,7 +808,6 @@ jumbo_static_library("extensions") {
+     "//chrome/browser/media/router",
+     "//chrome/browser/media/router/discovery",
+     "//chrome/browser/resource_coordinator:mojo_bindings",
+-    "//chrome/browser/safe_browsing",
+     "//chrome/browser/web_applications/components",
+     "//chrome/browser/web_applications/extensions",
+     "//chrome/common",
+--- a/chrome/browser/prefs/browser_prefs.cc
++++ b/chrome/browser/prefs/browser_prefs.cc
+@@ -109,7 +109,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/proxy_config/pref_proxy_config_tracker_impl.h"
+ #include "components/rappor/rappor_service_impl.h"
+-#include "components/safe_browsing/common/safe_browsing_prefs.h"
+ #include "components/search_engines/template_url_prepopulate_data.h"
+ #include "components/sessions/core/session_id_generator.h"
+ #include "components/startup_metric_utils/browser/startup_metric_utils.h"
+@@ -301,14 +300,11 @@
+ #if defined(OS_WIN)
+ #include "chrome/browser/apps/platform_apps/app_launch_for_metro_restart_win.h"
+ #include "chrome/browser/browser_switcher/browser_switcher_prefs.h"
+-#include "chrome/browser/component_updater/sw_reporter_installer_win.h"
+ #if defined(GOOGLE_CHROME_BUILD)
+ #include "chrome/browser/conflicts/incompatible_applications_updater_win.h"
+ #include "chrome/browser/conflicts/module_database_win.h"
+ #include "chrome/browser/conflicts/third_party_conflicts_manager_win.h"
+ #endif  // defined(GOOGLE_CHROME_BUILD)
+-#include "chrome/browser/safe_browsing/chrome_cleaner/settings_resetter_win.h"
+-#include "chrome/browser/safe_browsing/settings_reset_prompt/settings_reset_prompt_prefs_manager.h"
+ #include "chrome/browser/ui/desktop_ios_promotion/desktop_ios_promotion_util.h"
+ #endif
+
+@@ -504,7 +500,6 @@ void RegisterLocalState(PrefRegistrySimple* registry) {
+
+ #if defined(OS_WIN)
+   app_metro_launch::RegisterPrefs(registry);
+-  component_updater::RegisterPrefsForSwReporter(registry);
+   desktop_ios_promotion::RegisterLocalPrefs(registry);
+ #if defined(GOOGLE_CHROME_BUILD)
+   IncompatibleApplicationsUpdater::RegisterLocalStatePrefs(registry);
+@@ -571,7 +566,6 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
+   ProtocolHandlerRegistry::RegisterProfilePrefs(registry);
+   PushMessagingAppIdentifier::RegisterProfilePrefs(registry);
+   RegisterBrowserUserPrefs(registry);
+-  safe_browsing::RegisterProfilePrefs(registry);
+   secure_origin_whitelist::RegisterProfilePrefs(registry);
+   SafeBrowsingTriggeredPopupBlocker::RegisterProfilePrefs(registry);
+   SessionStartupPref::RegisterProfilePrefs(registry);
+@@ -712,12 +706,8 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
+
+ #if defined(OS_WIN)
+   browser_switcher::prefs::RegisterProfilePrefs(registry);
+-  component_updater::RegisterProfilePrefsForSwReporter(registry);
+   desktop_ios_promotion::RegisterProfilePrefs(registry);
+   NetworkProfileBubble::RegisterProfilePrefs(registry);
+-  safe_browsing::SettingsResetPromptPrefsManager::RegisterProfilePrefs(
+-      registry);
+-  safe_browsing::PostCleanupSettingsResetter::RegisterProfilePrefs(registry);
+ #endif
+
+ #if defined(TOOLKIT_VIEWS)
+--- a/chrome/browser/profiles/off_the_record_profile_io_data.cc
++++ b/chrome/browser/profiles/off_the_record_profile_io_data.cc
+@@ -177,14 +177,6 @@ void OffTheRecordProfileIOData::Handle::LazyInitialize() const {
+   // Set initialized_ to true at the beginning in case any of the objects
+   // below try to get the ResourceContext pointer.
+   initialized_ = true;
+-  io_data_->safe_browsing_enabled()->Init(prefs::kSafeBrowsingEnabled,
+-      profile_->GetPrefs());
+-  io_data_->safe_browsing_enabled()->MoveToThread(
+-      BrowserThread::GetTaskRunnerForThread(BrowserThread::IO));
+-  io_data_->safe_browsing_whitelist_domains()->Init(
+-      prefs::kSafeBrowsingWhitelistDomains, profile_->GetPrefs());
+-  io_data_->safe_browsing_whitelist_domains()->MoveToThread(
+-      BrowserThread::GetTaskRunnerForThread(BrowserThread::IO));
+ #if BUILDFLAG(ENABLE_PLUGINS)
+   io_data_->always_open_pdf_externally()->Init(
+       prefs::kPluginsAlwaysOpenPdfExternally, profile_->GetPrefs());
+--- a/chrome/browser/profiles/profile_impl_io_data.cc
++++ b/chrome/browser/profiles/profile_impl_io_data.cc
+@@ -378,14 +378,6 @@ void ProfileImplIOData::Handle::LazyInitialize() const {
+   // below try to get the ResourceContext pointer.
+   initialized_ = true;
+   PrefService* pref_service = profile_->GetPrefs();
+-  io_data_->safe_browsing_enabled()->Init(prefs::kSafeBrowsingEnabled,
+-      pref_service);
+-  io_data_->safe_browsing_enabled()->MoveToThread(
+-      BrowserThread::GetTaskRunnerForThread(BrowserThread::IO));
+-  io_data_->safe_browsing_whitelist_domains()->Init(
+-      prefs::kSafeBrowsingWhitelistDomains, pref_service);
+-  io_data_->safe_browsing_whitelist_domains()->MoveToThread(
+-      BrowserThread::GetTaskRunnerForThread(BrowserThread::IO));
+ #if BUILDFLAG(ENABLE_PLUGINS)
+   io_data_->always_open_pdf_externally()->Init(
+       prefs::kPluginsAlwaysOpenPdfExternally, pref_service);
+--- a/chrome/browser/ui/BUILD.gn
++++ b/chrome/browser/ui/BUILD.gn
+@@ -841,7 +841,6 @@ jumbo_split_static_library("ui") {
+     "//chrome/browser/engagement:mojo_bindings",
+     "//chrome/browser/media:mojo_bindings",
+     "//chrome/browser/profiling_host",
+-    "//chrome/browser/safe_browsing",
+     "//chrome/browser/ssl:proto",
+     "//chrome/browser/ui/webui/bluetooth_internals",
+     "//chrome/browser/ui/webui/interventions_internals:mojo_bindings",
+@@ -2567,10 +2566,6 @@ jumbo_split_static_library("ui") {
+       "network_profile_bubble.h",
+       "startup/default_browser_prompt_win.cc",
+       "views/certificate_viewer_win.cc",
+-      "views/chrome_cleaner_dialog_win.cc",
+-      "views/chrome_cleaner_dialog_win.h",
+-      "views/chrome_cleaner_reboot_dialog_win.cc",
+-      "views/chrome_cleaner_reboot_dialog_win.h",
+       "views/color_chooser_dialog.cc",
+       "views/color_chooser_dialog.h",
+       "views/color_chooser_win.cc",
+--- a/chrome/browser/ui/browser_dialogs.h
++++ b/chrome/browser/ui/browser_dialogs.h
+@@ -50,9 +50,6 @@ class PaymentRequestDialog;
+ }
+
+ namespace safe_browsing {
+-class ChromeCleanerController;
+-class ChromeCleanerDialogController;
+-class ChromeCleanerRebootDialogController;
+ class SettingsResetPromptController;
+ }
+
+@@ -294,21 +291,6 @@ void ShowSettingsResetPrompt(
+     Browser* browser,
+     safe_browsing::SettingsResetPromptController* controller);
+
+-// Shows the Chrome Cleanup dialog asking the user if they want to clean their
+-// system from unwanted software. This is called when unwanted software has been
+-// detected on the system.
+-void ShowChromeCleanerPrompt(
+-    Browser* browser,
+-    safe_browsing::ChromeCleanerDialogController* dialog_controller,
+-    safe_browsing::ChromeCleanerController* cleaner_controller);
+-
+-// Shows the Chrome Cleanup reboot dialog asking the user if they want to
+-// restart their computer once a cleanup has finished. This is called when the
+-// Chrome Cleanup ends in a reboot required state.
+-void ShowChromeCleanerRebootPrompt(
+-    Browser* browser,
+-    safe_browsing::ChromeCleanerRebootDialogController* dialog_controller);
+-
+ #endif  // OS_WIN
+
+ }  // namespace chrome
 --- a/chrome/browser/ui/webui/settings/chrome_cleanup_handler.cc
 +++ b/chrome/browser/ui/webui/settings/chrome_cleanup_handler.cc
-@@ -275,8 +275,6 @@ void ChromeCleanupHandler::HandleStartCl
+@@ -275,8 +275,6 @@ void ChromeCleanupHandler::HandleStartCleanup(const base::ListValue* args) {
    // The state is propagated to all open tabs and should be consistent.
    DCHECK_EQ(controller_->logs_enabled(), allow_logs_upload);
- 
+
 -  safe_browsing::RecordCleanupStartedHistogram(
 -      safe_browsing::CLEANUP_STARTED_FROM_PROMPT_IN_SETTINGS);
    base::RecordAction(
        base::UserMetricsAction("SoftwareReporter.CleanupWebui_StartCleanup"));
- 
+
 --- a/chrome/browser/ui/webui/settings/md_settings_ui.cc
 +++ b/chrome/browser/ui/webui/settings/md_settings_ui.cc
-@@ -52,9 +52,6 @@
+@@ -54,9 +54,6 @@
  #include "printing/buildflags/buildflags.h"
- 
+
  #if defined(OS_WIN)
 -#include "chrome/browser/safe_browsing/chrome_cleaner/chrome_cleaner_controller_win.h"
 -#include "chrome/browser/safe_browsing/chrome_cleaner/srt_field_trial_win.h"
@@ -132,20 +272,21 @@
  #if defined(GOOGLE_CHROME_BUILD)
  #include "chrome/browser/conflicts/incompatible_applications_updater_win.h"
  #include "chrome/browser/conflicts/token_util_win.h"
-@@ -240,7 +237,6 @@ MdSettingsUI::MdSettingsUI(content::WebU
+@@ -257,7 +254,6 @@ MdSettingsUI::MdSettingsUI(content::WebUI* web_ui)
        content::WebUIDataSource::Create(chrome::kChromeUISettingsHost);
- 
+
  #if defined(OS_WIN)
 -  AddSettingsPageUIHandler(std::make_unique<ChromeCleanupHandler>(profile));
- 
+
  #if defined(GOOGLE_CHROME_BUILD)
    html_source->AddResourcePath("partner-logo.svg", IDR_CHROME_CLEANUP_PARTNER);
 --- a/chrome/common/safe_browsing/BUILD.gn
 +++ b/chrome/common/safe_browsing/BUILD.gn
-@@ -96,43 +96,8 @@ source_set("safe_browsing") {
+@@ -95,44 +95,8 @@ source_set("safe_browsing") {
+   deps = [
      ":file_type_policies",
    ]
- 
+-
 -  if (safe_browsing_mode == 1) {
 -    sources = [
 -      "binary_feature_extractor.cc",
@@ -190,128 +331,22 @@
 +    "pe_image_reader_win.h",
 +  ]
  }
---- a/chrome/browser/chrome_browser_main.cc
-+++ b/chrome/browser/chrome_browser_main.cc
-@@ -241,7 +241,6 @@
- #include "base/trace_event/trace_event_etw_export_win.h"
- #include "base/win/win_util.h"
- #include "chrome/browser/chrome_browser_main_win.h"
--#include "chrome/browser/component_updater/sw_reporter_installer_win.h"
- #if defined(GOOGLE_CHROME_BUILD)
- #include "chrome/browser/component_updater/third_party_module_list_component_installer_win.h"
- #endif  // defined(GOOGLE_CHROME_BUILD)
-@@ -603,7 +602,6 @@ void RegisterComponentsForUpdate(PrefSer
-   // on chromium build bots, it is always registered here and
-   // RegisterSwReporterComponent() has support for running only in official
-   // builds or tests.
--  RegisterSwReporterComponent(cus);
- #if defined(GOOGLE_CHROME_BUILD)
-   RegisterThirdPartyModuleListComponent(cus);
- #endif  // defined(GOOGLE_CHROME_BUILD)
---- a/chrome/browser/prefs/browser_prefs.cc
-+++ b/chrome/browser/prefs/browser_prefs.cc
-@@ -106,7 +106,6 @@
- #include "components/prefs/pref_service.h"
- #include "components/proxy_config/pref_proxy_config_tracker_impl.h"
- #include "components/rappor/rappor_service_impl.h"
--#include "components/safe_browsing/common/safe_browsing_prefs.h"
- #include "components/search_engines/template_url_prepopulate_data.h"
- #include "components/sessions/core/session_id_generator.h"
- #include "components/startup_metric_utils/browser/startup_metric_utils.h"
-@@ -291,14 +290,11 @@
- 
- #if defined(OS_WIN)
- #include "chrome/browser/apps/platform_apps/app_launch_for_metro_restart_win.h"
--#include "chrome/browser/component_updater/sw_reporter_installer_win.h"
- #if defined(GOOGLE_CHROME_BUILD)
- #include "chrome/browser/conflicts/incompatible_applications_updater_win.h"
- #include "chrome/browser/conflicts/module_database_win.h"
- #include "chrome/browser/conflicts/third_party_conflicts_manager_win.h"
- #endif  // defined(GOOGLE_CHROME_BUILD)
--#include "chrome/browser/safe_browsing/chrome_cleaner/settings_resetter_win.h"
--#include "chrome/browser/safe_browsing/settings_reset_prompt/settings_reset_prompt_prefs_manager.h"
- #include "chrome/browser/ui/desktop_ios_promotion/desktop_ios_promotion_util.h"
- #endif
- 
-@@ -490,7 +486,6 @@ void RegisterLocalState(PrefRegistrySimp
- 
- #if defined(OS_WIN)
-   app_metro_launch::RegisterPrefs(registry);
--  component_updater::RegisterPrefsForSwReporter(registry);
-   desktop_ios_promotion::RegisterLocalPrefs(registry);
-   password_manager::PasswordManager::RegisterLocalPrefs(registry);
- #if defined(GOOGLE_CHROME_BUILD)
-@@ -557,7 +552,6 @@ void RegisterProfilePrefs(user_prefs::Pr
-   ProtocolHandlerRegistry::RegisterProfilePrefs(registry);
-   PushMessagingAppIdentifier::RegisterProfilePrefs(registry);
-   RegisterBrowserUserPrefs(registry);
--  safe_browsing::RegisterProfilePrefs(registry);
-   secure_origin_whitelist::RegisterProfilePrefs(registry);
-   SafeBrowsingTriggeredPopupBlocker::RegisterProfilePrefs(registry);
-   SessionStartupPref::RegisterProfilePrefs(registry);
-@@ -693,12 +687,8 @@ void RegisterProfilePrefs(user_prefs::Pr
- #endif
- 
- #if defined(OS_WIN)
--  component_updater::RegisterProfilePrefsForSwReporter(registry);
-   desktop_ios_promotion::RegisterProfilePrefs(registry);
-   NetworkProfileBubble::RegisterProfilePrefs(registry);
--  safe_browsing::SettingsResetPromptPrefsManager::RegisterProfilePrefs(
--      registry);
--  safe_browsing::PostCleanupSettingsResetter::RegisterProfilePrefs(registry);
- #endif
- 
- #if defined(TOOLKIT_VIEWS)
---- a/chrome/browser/profiles/profile_impl_io_data.cc
-+++ b/chrome/browser/profiles/profile_impl_io_data.cc
-@@ -358,14 +358,6 @@ void ProfileImplIOData::Handle::LazyInit
-   // below try to get the ResourceContext pointer.
-   initialized_ = true;
-   PrefService* pref_service = profile_->GetPrefs();
--  io_data_->safe_browsing_enabled()->Init(prefs::kSafeBrowsingEnabled,
--      pref_service);
--  io_data_->safe_browsing_enabled()->MoveToThread(
--      BrowserThread::GetTaskRunnerForThread(BrowserThread::IO));
--  io_data_->safe_browsing_whitelist_domains()->Init(
--      prefs::kSafeBrowsingWhitelistDomains, pref_service);
--  io_data_->safe_browsing_whitelist_domains()->MoveToThread(
--      BrowserThread::GetTaskRunnerForThread(BrowserThread::IO));
- #if BUILDFLAG(ENABLE_PLUGINS)
-   io_data_->always_open_pdf_externally()->Init(
-       prefs::kPluginsAlwaysOpenPdfExternally, pref_service);
---- a/chrome/browser/profiles/off_the_record_profile_io_data.cc
-+++ b/chrome/browser/profiles/off_the_record_profile_io_data.cc
-@@ -162,14 +162,6 @@ void OffTheRecordProfileIOData::Handle::
-   // Set initialized_ to true at the beginning in case any of the objects
-   // below try to get the ResourceContext pointer.
-   initialized_ = true;
--  io_data_->safe_browsing_enabled()->Init(prefs::kSafeBrowsingEnabled,
--      profile_->GetPrefs());
--  io_data_->safe_browsing_enabled()->MoveToThread(
--      BrowserThread::GetTaskRunnerForThread(BrowserThread::IO));
--  io_data_->safe_browsing_whitelist_domains()->Init(
--      prefs::kSafeBrowsingWhitelistDomains, profile_->GetPrefs());
--  io_data_->safe_browsing_whitelist_domains()->MoveToThread(
--      BrowserThread::GetTaskRunnerForThread(BrowserThread::IO));
- #if BUILDFLAG(ENABLE_PLUGINS)
-   io_data_->always_open_pdf_externally()->Init(
-       prefs::kPluginsAlwaysOpenPdfExternally, profile_->GetPrefs());
 --- a/chrome/renderer/url_loader_throttle_provider_impl.cc
 +++ b/chrome/renderer/url_loader_throttle_provider_impl.cc
-@@ -59,8 +59,7 @@ URLLoaderThrottleProviderImpl::URLLoader
+@@ -110,8 +110,7 @@ URLLoaderThrottleProviderImpl::URLLoaderThrottleProviderImpl(
        chrome_content_renderer_client_(chrome_content_renderer_client) {
    DETACH_FROM_THREAD(thread_checker_);
- 
+
 -  if (base::FeatureList::IsEnabled(network::features::kNetworkService) ||
 -      base::FeatureList::IsEnabled(safe_browsing::kCheckByURLLoaderThrottle)) {
 +  if (base::FeatureList::IsEnabled(network::features::kNetworkService)) {
      content::RenderThread::Get()->GetConnector()->BindInterface(
          content::mojom::kBrowserServiceName,
          mojo::MakeRequest(&safe_browsing_info_));
-@@ -107,10 +106,7 @@ URLLoaderThrottleProviderImpl::CreateThr
+@@ -158,10 +157,7 @@ URLLoaderThrottleProviderImpl::CreateThrottles(
    DCHECK(!is_frame_resource ||
           type_ == content::URLLoaderThrottleProviderType::kFrame);
- 
+
 -  if ((network_service_enabled ||
 -       base::FeatureList::IsEnabled(
 -           safe_browsing::kCheckByURLLoaderThrottle)) &&
@@ -320,37 +355,3 @@
      if (safe_browsing_info_)
        safe_browsing_.Bind(std::move(safe_browsing_info_));
      throttles.push_back(
---- a/chrome/browser/ui/browser_dialogs.h
-+++ b/chrome/browser/ui/browser_dialogs.h
-@@ -50,9 +50,6 @@ class PaymentRequestDialog;
- }
- 
- namespace safe_browsing {
--class ChromeCleanerController;
--class ChromeCleanerDialogController;
--class ChromeCleanerRebootDialogController;
- class SettingsResetPromptController;
- }
- 
-@@ -285,21 +282,6 @@ void ShowSettingsResetPrompt(
-     Browser* browser,
-     safe_browsing::SettingsResetPromptController* controller);
- 
--// Shows the Chrome Cleanup dialog asking the user if they want to clean their
--// system from unwanted software. This is called when unwanted software has been
--// detected on the system.
--void ShowChromeCleanerPrompt(
--    Browser* browser,
--    safe_browsing::ChromeCleanerDialogController* dialog_controller,
--    safe_browsing::ChromeCleanerController* cleaner_controller);
--
--// Shows the Chrome Cleanup reboot dialog asking the user if they want to
--// restart their computer once a cleanup has finished. This is called when the
--// Chrome Cleanup ends in a reboot required state.
--void ShowChromeCleanerRebootPrompt(
--    Browser* browser,
--    safe_browsing::ChromeCleanerRebootDialogController* dialog_controller);
--
- #endif  // OS_WIN
- 
- }  // namespace chrome

--- a/patches/ungoogled-chromium/windows/windows-fix-enum-conflict.patch
+++ b/patches/ungoogled-chromium/windows/windows-fix-enum-conflict.patch
@@ -2,7 +2,7 @@
 
 --- a/extensions/browser/api/feedback_private/feedback_private_api.cc
 +++ b/extensions/browser/api/feedback_private/feedback_private_api.cc
-@@ -370,7 +370,7 @@ void FeedbackPrivateSendFeedbackFunction
+@@ -370,7 +370,7 @@ void FeedbackPrivateSendFeedbackFunction::OnCompleted(
      bool success) {
    Respond(TwoArguments(
        std::make_unique<base::Value>(feedback_private::ToString(
@@ -15,10 +15,10 @@
 +++ b/extensions/common/api/feedback_private.idl
 @@ -91,7 +91,7 @@ namespace feedbackPrivate {
    };
- 
+
    // Status of the sending of a feedback report.
 -  enum Status {success, delayed};
 +  enum Status {success1, delayed};
- 
+
    // The type of the landing page shown to the user when the feedback report is
    // successfully sent.


### PR DESCRIPTION
Closes #475 

@Eloston Try to fix Windows build but I'm encountering an other now :

```
patching file chrome/browser/BUILD.gn
patching file chrome/browser/chrome_browser_main.cc
patching file chrome/browser/chrome_browser_main_win.cc
patching file chrome/browser/extensions/BUILD.gn
patching file chrome/browser/prefs/browser_prefs.cc
patching file chrome/browser/profiles/off_the_record_profile_io_data.cc
patching file chrome/browser/profiles/profile_impl_io_data.cc
patching file chrome/browser/ui/BUILD.gn
Hunk #1 succeeded at 837 (offset -4 lines).
Hunk #2 succeeded at 2562 (offset -4 lines).
patching file chrome/browser/ui/browser_dialogs.h
patching file chrome/browser/ui/webui/settings/chrome_cleanup_handler.cc
patching file chrome/browser/ui/webui/settings/md_settings_ui.cc
patching file chrome/common/safe_browsing/BUILD.gn
patching file chrome/renderer/url_loader_throttle_provider_impl.cc
2018-11-20 18:54:22,124 - INFO: * Applying windows-fix-enum-conflict.patch (123/126)
2018-11-20 18:54:22,124 - DEBUG: C:\msys32\usr\bin\patch.EXE -p1 --ignore-whitespace -i X:\ungoogled-chromium\build\src\ungoogled_packaging\patches\ungoogled-chromium\windows\windows-fix-enum-conflict.patch -d X:\ungoogled-chromium\build\src --no-backup-if-mismatch --forward
patching file extensions/browser/api/feedback_private/feedback_private_api.cc
patching file extensions/common/api/feedback_private.idl
2018-11-20 18:54:22,240 - INFO: * Applying windows-fix-building-gn.patch (124/126)
2018-11-20 18:54:22,241 - DEBUG: C:\msys32\usr\bin\patch.EXE -p1 --ignore-whitespace -i X:\ungoogled-chromium\build\src\ungoogled_packaging\patches\ungoogled-chromium\windows\windows-fix-building-gn.patch -d X:\ungoogled-chromium\build\src --no-backup-if-mismatch --forward
patching file tools/gn/bootstrap/bootstrap.py
Hunk #1 succeeded at 58 (offset -4 lines).
Hunk #2 succeeded at 75 (offset -6 lines).
patching file tools/gn/build/build_win.ninja.template
2018-11-20 18:54:22,337 - INFO: * Applying windows-disable-encryption.patch (125/126)
2018-11-20 18:54:22,337 - DEBUG: C:\msys32\usr\bin\patch.EXE -p1 --ignore-whitespace -i X:\ungoogled-chromium\build\src\ungoogled_packaging\patches\ungoogled-chromium\windows\windows-disable-encryption.patch -d X:\ungoogled-chromium\build\src --no-backup-if-mismatch --forward
patching file components/os_crypt/os_crypt_win.cc
2018-11-20 18:54:22,421 - INFO: * Applying windows-disable-machine-id.patch (126/126)
2018-11-20 18:54:22,421 - DEBUG: C:\msys32\usr\bin\patch.EXE -p1 --ignore-whitespace -i X:\ungoogled-chromium\build\src\ungoogled_packaging\patches\ungoogled-chromium\windows\windows-disable-machine-id.patch -d X:\ungoogled-chromium\build\src --no-backup-if-mismatch --forward
patching file components/metrics/machine_id_provider_win.cc
patching file services/preferences/tracked/device_id_win.cc
Traceback (most recent call last):
  File "ungoogled_packaging/build.py", line 187, in <module>
    main()
  File "ungoogled_packaging/build.py", line 167, in main
    buildkit.domain_substitution.apply_substitution(bundle, source_tree, domsubcache)
  File "X:\ungoogled-chromium\build\src\ungoogled_packaging\buildkit\domain_substitution.py", line 130, in apply_substitution
    raise FileExistsError(domainsub_cache)
FileExistsError: ungoogled_packaging\domsubcache.tar.gz
```

**EDIT**

Ok going a stup futher now, I have removed `ungoogled_packaging\domsubcache.tar.gz` (probably not removed when build fails) :

```
Remarque▒: inclusion du fichier▒:       X:\ungoogled-chromium\build\src\tools\gn\tools/gn/substitution_type.h
Remarque▒: inclusion du fichier▒:    X:\ungoogled-chromium\build\src\tools\gn\tools/gn/bundle_data.h
Remarque▒: inclusion du fichier▒:     X:\ungoogled-chromium\build\src\tools\gn\tools/gn/bundle_file_rule.h
Remarque▒: inclusion du fichier▒:    X:\ungoogled-chromium\build\src\tools\gn\tools/gn/config_values.h
Remarque▒: inclusion du fichier▒:     X:\ungoogled-chromium\build\src\tools\gn\tools/gn/lib_file.h
Remarque▒: inclusion du fichier▒:    X:\ungoogled-chromium\build\src\tools\gn\tools/gn/inherited_libraries.h
Remarque▒: inclusion du fichier▒:    X:\ungoogled-chromium\build\src\tools\gn\tools/gn/ordered_set.h
Remarque▒: inclusion du fichier▒:    X:\ungoogled-chromium\build\src\tools\gn\tools/gn/output_file.h
Remarque▒: inclusion du fichier▒:    X:\ungoogled-chromium\build\src\tools\gn\tools/gn/toolchain.h
Remarque▒: inclusion du fichier▒:     X:\ungoogled-chromium\build\src\tools\gn\tools/gn/source_file_type.h
Remarque▒: inclusion du fichier▒:     X:\ungoogled-chromium\build\src\tools\gn\tools/gn/tool.h
Remarque▒: inclusion du fichier▒:  X:\ungoogled-chromium\build\src\tools\gn\tools/gn/deps_iterator.h
Remarque▒: inclusion du fichier▒:  X:\ungoogled-chromium\build\src\tools\gn\tools/gn/filesystem_utils.h
Remarque▒: inclusion du fichier▒:   X:\ungoogled-chromium\build\src\tools\gn\tools/gn/settings.h
Remarque▒: inclusion du fichier▒:    X:\ungoogled-chromium\build\src\tools\gn\tools/gn/import_manager.h
Remarque▒: inclusion du fichier▒:  X:\ungoogled-chromium\build\src\tools\gn\tools/gn/variables.h
Remarque▒: inclusion du fichier▒:  X:\ungoogled-chromium\build\src\tools\gn\tools/gn/xcode_object.h
[169/170] LIB gn_lib.lib
[170/170] LINK gn.exe
G▒n▒ration de code en cours
Fin de la g▒n▒ration du code

X:\ungoogled-chromium\build\src>exit
X:\ungoogled-chromium\build\src>call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat" >nul

X:\ungoogled-chromium\build\src>"out\Default\gn.exe" "gen" "out\Default" "--fail-on-unused-args"
ERROR at build arg file (use "gn args <out_dir>" to edit):574:1: Newline in string constant.
"
^-

X:\ungoogled-chromium\build\src>exit
Traceback (most recent call last):
  File "ungoogled_packaging/build.py", line 187, in <module>
    main()
  File "ungoogled_packaging/build.py", line 179, in main
    _run_build_process('out\\Default\\gn.exe', 'gen', 'out\\Default', '--fail-on-unused-args')
  File "ungoogled_packaging/build.py", line 65, in _run_build_process
    **kwargs)
  File "C:\Python37\lib\subprocess.py", line 481, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '('cmd.exe', '/k')' returned non-zero exit status 1.
```

**EDIT2**

I have removed `"` but :

```
$ "out\Default\gn.exe" gen out\Default --fail-on-unused-args
Traceback (most recent call last):
  File "X:/ungoogled-chromium/build/src/build/vs_toolchain.py", line 471, in <module>
    sys.exit(main())
  File "X:/ungoogled-chromium/build/src/build/vs_toolchain.py", line 467, in main
    return commands[sys.argv[1]](*sys.argv[2:])
  File "X:/ungoogled-chromium/build/src/build/vs_toolchain.py", line 442, in GetToolchainDir
    runtime_dll_dirs = SetEnvironmentAndGetRuntimeDllDirs()
  File "X:/ungoogled-chromium/build/src/build/vs_toolchain.py", line 45, in SetEnvironmentAndGetRuntimeDllDirs
    update_result = Update()
  File "X:/ungoogled-chromium/build/src/build/vs_toolchain.py", line 413, in Update
    subprocess.check_call(get_toolchain_args)
  File "C:\Python27\lib\subprocess.py", line 190, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['C:\\Python27\\python.exe', 'X:\\ungoogled-chromium\\build\\src\\third_party\\depot_tools\\win_toolchain\\get_toolchain_if_necessary.py', '--output-json', 'X:\\ungoogled-chromium\\build\\src\\build\\win_toolchain.json', '3bc0ec615cf20ee342f3bc29bc991b5ad66d8d2c']' returned non-zero exit status 1
ERROR at //build/config/win/visual_studio_version.gni:27:7: Script returned non-zero exit code.
      exec_script("../../vs_toolchain.py", [ "get_toolchain_dir" ], "scope")
      ^----------
Current dir: X:/ungoogled-chromium/build/src/outDefault/
Command: C:/Python27/python.exe X:/ungoogled-chromium/build/src/build/vs_toolchain.py get_toolchain_dir
Returned 1 and printed out:




Please follow the instructions at https://chromium.9oo91esource.qjz9zk/chromium/src/+/master/docs/windows_build_instructions.md



See //third_party/angle/gni/angle.gni:79:3: whence it was imported.
  import("//build/config/win/visual_studio_version.gni")
  ^----------------------------------------------------
See //chrome/elevation_service/BUILD.gn:6:1: whence it was imported.
import("//build/toolchain/win/midl.gni")
^--------------------------------------
See //BUILD.gn:563:7: which caused the file to be included.
      "//chrome/elevation_service:elevation_service_unittests",
      ^-------------------------------------------------------
```

**EDIT3**

Ok it works. I have added the env var `DEPOT_TOOLS_WIN_TOOLCHAIN=0` according to [build instructions of Chromium](https://chromium.googlesource.com/chromium/src/+/master/docs/windows_build_instructions.md#install) :

```
$ export DEPOT_TOOLS_WIN_TOOLCHAIN=0
$ "out\Default\gn.exe" gen out\Default --fail-on-unused-args
Done. Made 9563 targets from 1656 files in 13223ms
```

**EDIT4**

Ninja hurts, toolchain folder is missing :

```
$ "third_party\ninja\ninja.exe" -C out/Default chrome chromedriver
ninja: Entering directory `outDefault'
ninja: error: '../native_client/toolchain/win_x86/pnacl_newlib/bin/x86_64-nacl-objcopy.exe', needed by 'nacl_irt_x86_64.nexe', missing and no known rule to make it
```

**EDIT5**

Now wait & see

```
$ "third_party\ninja\ninja.exe" -C out/Default chrome chromedriver
ninja: Entering directory `out/Default'
[1/35434] ACTION //chrome:chrome_exe_version_action(//build/toolchain/win:win_clang_x64)
[2/35434] ACTION //base:build_date(//build/toolchain/win:win_clang_x64)
[3/35434] STAMP obj/build/buildflag_header_h.stamp
[4/35434] STAMP obj/base/allocator/allocator.stamp
[5/35434] STAMP obj/base/numerics/base_numerics.stamp
[6/35434] STAMP obj/chrome/chrome_exe_version_action.stamp
[7/35434] ACTION //base/trace_event/etw_manifest:chrome_events_win(//build/toolchain/win:win_clang_x64)
[8/35434] COPY ../chrome/app/FirstRun "First Run"
[9/35434] ACTION //base:debugging_buildflags(//build/toolchain/win:win_clang_x64)
[10/35434] ACTION //base:cfi_buildflags(//build/toolchain/win:win_clang_x64)
[11/35434] ACTION //base:partition_alloc_buildflags(//build/toolchain/win:win_clang_x64)
[12/35434] STAMP obj/base/debugging_buildflags.stamp
[13/35434] STAMP obj/base/cfi_buildflags.stamp
[14/35434] ACTION //base/allocator:buildflags(//build/toolchain/win:win_clang_x64)
[15/35434] ACTION //base:orderfile_buildflags(//build/toolchain/win:win_clang_x64)
[16/35434] STAMP obj/base/partition_alloc_buildflags.stamp
[17/35434] STAMP obj/base/build_date.stamp
[18/35434] ACTION //base:protected_memory_buildflags(//build/toolchain/win:win_clang_x64)
[19/35434] STAMP obj/base/orderfile_buildflags.stamp
[20/35434] STAMP obj/base/allocator/buildflags.stamp
[21/35434] STAMP obj/base/protected_memory_buildflags.stamp
[22/35434] ACTION //base:synchronization_buildflags(//build/toolchain/win:win_clang_x64)
[23/35434] ACTION //chrome/app/version_assembly:chrome_exe_version_manifest_action(//build/toolchain/win:win_clang_x64)
[24/35434] ACTION //chrome/app/version_assembly:version_assembly_manifest(//build/toolchain/win:win_clang_x64)
[25/35434] STAMP obj/base/synchronization_buildflags.stamp
[26/35434] CXX obj/base/base_static/base_switches.obj
```