### PR TITLE
Windows - Fix build.py so that args.gn is properly created

### DIFF
--- a/packaging/windows/build.py
+++ b/packaging/windows/build.py
@@ -168,8 +168,7 @@ def main():
 
     # Output args.gn
     (source_tree / 'out/Default').mkdir(parents=True)
-    (source_tree / 'out/Default/args.gn').write_text(
-        '\n'.join(str(bundle.gn_flags)), encoding=ENCODING)
+    (source_tree / 'out/Default/args.gn').write_text(str(bundle.gn_flags), encoding=ENCODING)
 
     # Run GN bootstrap
     _run_build_process(


### PR DESCRIPTION
Fixes ungoogled-chromium bug #604
