### PR TITLE
Fix macOS build

### DIFF
--- a/config_bundles/macos/patch_order.list
+++ b/config_bundles/macos/patch_order.list
@@ -4,3 +4,4 @@ ungoogled-chromium/macos/fix-gn-safe_browsing.patch
 ungoogled-chromium/macos/fix-mapped_file.patch
 ungoogled-chromium/macos/fix-visibility.patch
 ungoogled-chromium/macos/fix-older-sdk-declarations.patch
+ungoogled-chromium/macos/fix-disk_image_type_sniffer_mac.patch

--- a/packaging/macos/build.sh.ungoogin
+++ b/packaging/macos/build.sh.ungoogin
@@ -31,7 +31,7 @@ python3 -m buildkit domains apply -b config_bundles/macos -c domainsubcache.tar.
 python3 -m buildkit gnargs print -b config_bundles/macos > ../out/Default/args.gn
 popd
 
-./tools/gn/bootstrap/bootstrap.py -o out/Default/gn --skip-generate-buildfiles
+./tools/gn/bootstrap/bootstrap.py --build-path out/Default -o out/Default/gn --skip-generate-buildfiles
 ./out/Default/gn gen out/Default --fail-on-unused-args
 ninja -C out/Default chrome chromedriver
 chrome/installer/mac/pkg-dmg --source /var/empty --target "${packaging_dir}/ungoogled-chromium_$ungoog{chromium_version}-$ungoog{release_revision}_macos.dmg" --format UDBZ --verbosity 2 --volname Chromium --copy "out/Default/Chromium.app/:/Chromium.app/" --symlink "/Applications:/Drag to here to install"

--- a/patches/ungoogled-chromium/macos/fix-disk_image_type_sniffer_mac.patch
+++ b/patches/ungoogled-chromium/macos/fix-disk_image_type_sniffer_mac.patch
@@ -1,0 +1,20 @@
+# Fix safebrowsing build on macOS ("disk_image_type_sniffer_mac" is set only if safe_browsing_mode == 1)
+
+--- chrome/common/safe_browsing/BUILD.gn	2018-12-13 23:09:09.000000000 +0300
++++ b/chrome/common/safe_browsing/BUILD.gn	2018-12-13 23:10:15.000000000 +0300
+@@ -73,11 +73,11 @@
+     ":file_type_policies",
+   ]
+ 
+-  if (is_mac) {
+-    deps += [ ":disk_image_type_sniffer_mac" ]
+-  }
+-
+   if (safe_browsing_mode == 1) {
++    if (is_mac) {
++      deps += [ ":disk_image_type_sniffer_mac" ]
++    }
++
+     sources = [
+       "binary_feature_extractor.cc",
+       "binary_feature_extractor.h",

--- a/patches/ungoogled-chromium/macos/fix-disk_image_type_sniffer_mac.patch
+++ b/patches/ungoogled-chromium/macos/fix-disk_image_type_sniffer_mac.patch
@@ -1,7 +1,7 @@
 # Fix safebrowsing build on macOS ("disk_image_type_sniffer_mac" is set only if safe_browsing_mode == 1)
 
---- chrome/common/safe_browsing/BUILD.gn	2018-12-13 23:09:09.000000000 +0300
-+++ b/chrome/common/safe_browsing/BUILD.gn	2018-12-13 23:10:15.000000000 +0300
+--- a/chrome/common/safe_browsing/BUILD.gn
++++ b/chrome/common/safe_browsing/BUILD.gn
 @@ -73,11 +73,11 @@
      ":file_type_policies",
    ]


### PR DESCRIPTION
This PR should fix build on macOS systems (still waiting for the build to finish).

The following issues I've encountered before running `ninja` are addressed:

1. Missing `--build-path` argument — `bootstrap.py` generated `out/Release` by default.

2. Since safe browsing is disabled, `disk_image_type_sniffer_mac` is never defined and should not be added to `deps` in that case.
