### PR TITLE
Clean up macOS build script

### DIFF
--- a/packaging/macos/build.sh.ungoogin
+++ b/packaging/macos/build.sh.ungoogin
@@ -1,37 +1,31 @@
-#!/bin/bash
-
-set -eux
-
+#!/bin/bash -eux
 # Simple build script for macOS
 
 packaging_dir=$(dirname $(greadlink -f $0))
 
-# Ensure /var/empty is actually empty, otherwise chrome/installer/mac/pkg-dmg
-# can fail. See issue https://github.com/Eloston/ungoogled-chromium/issues/425
-if [ -n "$(ls -A /var/empty 2>/dev/null)" ]
-then
-    echo 'ERROR: /var/empty is not empty!' >&2
-    exit 1
-fi
+# Place download_cache next the source tree, which is usually build/src
+cache="$packaging_dir/../../download_cache"
 
 rm -rf out || true
-mkdir out
-mkdir out/Default
+mkdir -p out/Default
+mkdir -p "$cache"
 
-# Place download_cache next the source tree, which is usually build/src
-DOWNLOAD_CACHE="$packaging_dir/../../download_cache"
-
-pushd ungoogled_packaging
-mkdir -p "$DOWNLOAD_CACHE" 
-python3 -m buildkit downloads retrieve -b config_bundles/macos -c "$DOWNLOAD_CACHE"
-python3 -m buildkit downloads unpack -b config_bundles/macos -c "$DOWNLOAD_CACHE" ../
+pushd "$packaging_dir"
+python3 -m buildkit downloads retrieve -b config_bundles/macos -c "$cache"
+python3 -m buildkit downloads unpack -b config_bundles/macos -c "$cache" ../
 python3 -m buildkit prune -b config_bundles/macos ../
 python3 -m buildkit patches apply -b config_bundles/macos ../
 python3 -m buildkit domains apply -b config_bundles/macos -c domainsubcache.tar.gz ../
 python3 -m buildkit gnargs print -b config_bundles/macos > ../out/Default/args.gn
 popd
 
-./tools/gn/bootstrap/bootstrap.py -o out/Default/gn --skip-generate-buildfiles
+./tools/gn/bootstrap/bootstrap.py --build-path out/Default -o out/Default/gn --skip-generate-buildfiles
 ./out/Default/gn gen out/Default --fail-on-unused-args
+
 ninja -C out/Default chrome chromedriver
-chrome/installer/mac/pkg-dmg --source /var/empty --target "${packaging_dir}/ungoogled-chromium_$ungoog{chromium_version}-$ungoog{release_revision}_macos.dmg" --format UDBZ --verbosity 2 --volname Chromium --copy "out/Default/Chromium.app/:/Chromium.app/" --symlink "/Applications:/Drag to here to install"
+
+chrome/installer/mac/pkg-dmg \
+  --sourcefile --source out/Default/Chromium.app \
+  --target "$packaging_dir/ungoogled-chromium_$ungoog{chromium_version}-$ungoog{release_revision}_macos.dmg" \
+  --volname Chromium --symlink /Applications:/Applications \
+  --format UDBZ --verbosity 2


### PR DESCRIPTION
Fixes #425 again.

Workaround introduced in 41b94e63feb8b278e308259822a24d158141a368 does not completely solve the problem.
However, `pkg-dmg` has `--sourcefile` flag which solves the problem.

>If this option is present, `--source` is treated as a file, and is
placed as a file within the volume's root folder.  Without this option,
`--source` is treated as the volume root itself.

Also changes the name of `/Applications` symlink to `Applications` — just to be consistent with all other application volumes.