### PR TITLE
Changes in Archlinux building script (PKGBUILD)

### DIFF
--- a/config_bundles/archlinux/patch_order.list
+++ b/config_bundles/archlinux/patch_order.list
@@ -1,0 +1,1 @@
+debian_buster/system/harfbuzz.patch

--- a/packaging/archlinux/PKGBUILD.ungoogin
+++ b/packaging/archlinux/PKGBUILD.ungoogin
@@ -16,7 +16,7 @@ url="https://github.com/Eloston/ungoogled-chromium"
 license=('BSD')
 depends=('gtk3' 'nss' 'alsa-lib' 'xdg-utils' 'libxss' 'libcups' 'libgcrypt'
          'ttf-font' 'systemd' 'dbus' 'libpulse' 'pciutils' 'json-glib'
-         'desktop-file-utils' 'hicolor-icon-theme')
+         'desktop-file-utils' 'hicolor-icon-theme' 'jsoncpp')
 makedepends=('python' 'python2' 'gperf' 'yasm' 'mesa' 'ninja' 'git'
              'clang' 'lld' 'gn' 'llvm' 'libva' 'quilt')
 optdepends=('pepper-flash: support for Flash content'


### PR DESCRIPTION
This pull request is actually not complete since the harfbuzz.patch file should be put in the same directory of the PKGBUILD by buildkit scripts for the build process to work.

I would therefore like to discuss whether sould be created an ad hoc directory to put PKGBUILD and patch in, or simply copy the .patch file in the same folder where PKGBUILD is generated.