### PR TITLE
buildkit: Fix download progress showing over 100%

### DIFF
--- a/buildkit/downloads.py
+++ b/buildkit/downloads.py
@@ -38,15 +38,16 @@ class _UrlRetrieveReportHook: #pylint: disable=too-few-public-methods
         self._last_percentage = None
 
     def __call__(self, block_count, block_size, total_size):
-        downloaded_estimate = block_count * block_size
-        percentage = round(downloaded_estimate / total_size, ndigits=3)
-        if percentage == self._last_percentage:
-            return # Do not needlessly update the console
-        self._last_percentage = percentage
-        print('\r' + ' ' * self._max_len_printed, end='')
         if total_size > 0:
+            total_blocks = (total_size + (block_size - total_size % block_size)) / block_size
+            percentage = block_count / total_blocks
+            if percentage == self._last_percentage:
+                return # Do not needlessly update the console
+            self._last_percentage = percentage
+            print('\r' + ' ' * self._max_len_printed, end='')
             status_line = 'Progress: {:.1%} of {:,d} B'.format(percentage, total_size)
         else:
+            downloaded_estimate = block_count * block_size
             status_line = 'Progress: {:,d} B of unknown size'.format(downloaded_estimate)
         self._max_len_printed = len(status_line)
         print('\r' + status_line, end='')


### PR DESCRIPTION
When running build.py I noticed the download progress percentage going over 100% due to downloaded estimate being too high as blocks are 8KB each. If you have a 644B file the estimate will be 8kb, ~1200% too high.

Also the else statement here would never trigger as line 42, `percentage = round(downloaded_estimate / total_size, ndigits=3)`, would divide by zero giving an error, so I adjusted the order.