### PR TITLE
Updating fix-gn-safe_browsing.patch on macos, fixes #678

### DIFF
--- a/patches/ungoogled-chromium/macos/fix-gn-safe_browsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-gn-safe_browsing.patch
@@ -1,16 +1,5 @@
 # Fix GN safe_browsing on macOS
 
---- a/build/config/compiler/BUILD.gn
-+++ b/build/config/compiler/BUILD.gn
-@@ -1497,7 +1497,7 @@ config("default_warnings") {
-         # recognize.
-         cflags += [
-           # TODO(thakis): https://crbug.com/753973
--          "-Wno-enum-compare-switch",
-+          # "-Wno-enum-compare-switch",
- 
-           # Ignore warnings about MSVC optimization pragmas.
-           # TODO(thakis): Only for no_chromium_code? http://crbug.com/505314
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
 @@ -1729,7 +1729,6 @@ jumbo_split_static_library("browser") {


### PR DESCRIPTION
This flag has already been removed in the 72.x.x.x branch of Chromium.

*(Please ensure you have read SUPPORT.md and docs/contributing.md before submitting the Pull Request)*
