### PR TITLE
packaging/arch: Update PKGBUILD

### DIFF
--- a/packaging/archlinux/PKGBUILD.ungoogin
+++ b/packaging/archlinux/PKGBUILD.ungoogin
@@ -15,10 +15,10 @@ arch=('x86_64')
 url="https://github.com/Eloston/ungoogled-chromium"
 license=('BSD')
 depends=('gtk3' 'nss' 'alsa-lib' 'xdg-utils' 'libxss' 'libcups' 'libgcrypt'
-         'ttf-font' 'systemd' 'dbus' 'libpulse' 'pciutils' 'json-glib'
+         'ttf-font' 'systemd' 'dbus' 'libpulse' 'pciutils' 'json-glib' 'libva'
          'desktop-file-utils' 'hicolor-icon-theme' 'jsoncpp')
 makedepends=('python' 'python2' 'gperf' 'yasm' 'mesa' 'ninja' 'git'
-             'clang' 'lld' 'gn' 'llvm' 'libva' 'quilt')
+             'clang' 'lld' 'gn' 'llvm' 'quilt')
 optdepends=('pepper-flash: support for Flash content'
             'kdialog: needed for file dialogs in KDE'
             'gnome-keyring: for storing passwords in GNOME keyring'
@@ -64,10 +64,10 @@ _unwanted_bundled_libs=(
 )
 depends+=(${_system_libs[@]})
 
-prepare() {
-  local _buildkit_cli="$srcdir/$pkgname-$ungoog{current_commit_or_tag}/run_buildkit_cli.py"
-  local _config_bundle="$srcdir/$pkgname-$ungoog{current_commit_or_tag}/config_bundles/archlinux"
+_buildkit_cli="$srcdir/$pkgname-$ungoog{current_commit_or_tag}/run_buildkit_cli.py"
+_config_bundle="$srcdir/$pkgname-$ungoog{current_commit_or_tag}/config_bundles/archlinux"
 
+prepare() {
   cd "$srcdir/chromium-$pkgver"
 
   msg2 'Pruning binaries'
@@ -116,9 +116,6 @@ build() {
   export NM=llvm-nm
 
   mkdir -p out/Default
-
-  local _buildkit_cli="$srcdir/$pkgname-$ungoog{current_commit_or_tag}/run_buildkit_cli.py"
-  local _config_bundle="$srcdir/$pkgname-$ungoog{current_commit_or_tag}/config_bundles/archlinux"
 
   python "$_buildkit_cli" gnargs print -b "$_config_bundle" \
     > "$srcdir/chromium-$pkgver/out/Default/args.gn"


### PR DESCRIPTION
- define 'libva' as a runtime dependency instead of a make dependency
- remove duplicate variable definitions