### PR TITLE
Remove -ignored-pragma-optimize on macOS, fixes #682

### DIFF
--- a/config_bundles/macos/patch_order.list
+++ b/config_bundles/macos/patch_order.list
@@ -5,3 +5,4 @@ ungoogled-chromium/macos/fix-mapped_file.patch
 ungoogled-chromium/macos/fix-visibility.patch
 ungoogled-chromium/macos/fix-older-sdk-declarations.patch
 ungoogled-chromium/macos/fix-disk_image_type_sniffer_mac.patch
+ungoogled-chromium/macos/fix-ignored-pragma-optimize.patch

--- a/patches/ungoogled-chromium/macos/fix-ignored-pragma-optimize.patch
+++ b/patches/ungoogled-chromium/macos/fix-ignored-pragma-optimize.patch
@@ -1,0 +1,18 @@
+# Removes the -Wno-ignored-pragma-optimize flag
+
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -1486,13 +1486,6 @@
+       }
+
+       if (current_toolchain == host_toolchain || !use_xcode_clang) {
+-        # Flags NaCl (Clang 3.7) and Xcode 9.2 (Clang clang-900.0.39.2) do not
+-        # recognize.
+-        cflags += [
+-          # Ignore warnings about MSVC optimization pragmas.
+-          # TODO(thakis): Only for no_chromium_code? http://crbug.com/505314
+-          "-Wno-ignored-pragma-optimize",
+-        ]
+         if (is_fuchsia) {
+           cflags += [
+             # TODO(hans): https://crbug.com/890307


### PR DESCRIPTION
Here is what I've found irt #682 :
* That section of build/config/compiler/Build.gn has been changed a lot lately (with some stuff that appears to be in the wrong place but... whatever), starting with [this](https://chromium-review.googlesource.com/c/chromium/src/+/1090151/12/build/config/compiler/BUILD.gn) and right now 
 in 74.x looking like [this](https://chromium.googlesource.com/chromium/src/+/refs/tags/74.0.3715.1/build/config/compiler/BUILD.gn#1509)... comparable to what we have in 72.x.
* They are not adding that flag if chromium is compiled with the clang bundled with xcode:
```
      if (current_toolchain == host_toolchain || !use_xcode_clang) {
        # Flags NaCl (Clang 3.7) and Xcode 9.2 (Clang clang-900.0.39.2) do not
        # recognize.
        cflags += [
          # Ignore warnings about MSVC optimization pragmas.
          # TODO(thakis): Only for no_chromium_code? http://crbug.com/505314
          "-Wno-ignored-pragma-optimize",
        ] 
```
but in our case (we compile with the clang-6.0 we downloaded) both parts of the condition are true.
My guess is that it's more of an issue with clang on macs that an issue with the specific clang shipped with xcode, chromium should probably rework some of those checks (but most people will use the clang they already have).

Regardless, since this is the result of how ungoogled-chromium is compiled I'm adding a patch for this, that removes just the option, hoping that it will be easy to adapt it when build.gn changes again.