### PR TITLE
Disable proxy controller

### DIFF
--- a/patches/ungoogled-chromium/disable-proxy-controller.patch
+++ b/patches/ungoogled-chromium/disable-proxy-controller.patch
@@ -1,0 +1,12 @@
+diff -Npur chromium-72.0.3626.96.orig/chrome/browser/extensions/proxy_overridden_bubble_delegate.cc chromium-72.0.3626.96/chrome/browser/extensions/proxy_overridden_bubble_delegate.cc
+--- chromium-72.0.3626.96.orig/chrome/browser/extensions/proxy_overridden_bubble_delegate.cc	2019-02-07 01:06:37.000000000 +0300
++++ chromium-72.0.3626.96/chrome/browser/extensions/proxy_overridden_bubble_delegate.cc	2019-03-02 17:57:12.119946332 +0300
+@@ -62,7 +62,7 @@ bool ProxyOverriddenBubbleDelegate::Shou
+   // Found the only extension; restrict to this one.
+   extension_id_ = extension->id();
+ 
+-  return true;
++  return false;
+ }
+ 
+ void ProxyOverriddenBubbleDelegate::AcknowledgeExtension(


### PR DESCRIPTION
A patch, which turns off proxy controller, which in turn can lead to a data leak, because of proxy extension shutdown.

https://codereview.chromium.org/320633002/