### PR TITLE
Update version.ini to 72.0.3626.122

### DIFF
--- a/version.ini
+++ b/version.ini
@@ -1,3 +1,3 @@
 [version]
-chromium_version = 72.0.3626.109
+chromium_version = 72.0.3626.122
 release_revision = 1


### PR DESCRIPTION
Contains a fix for CVE-2019-5786, see [announcement](https://chromereleases.googleblog.com/2019/03/stable-channel-update-for-chrome-os.html).
I'm compiling right now but all the patches seem to have applied correctly.

Note: Looks like that on [March 12th](https://chromiumdash.appspot.com/schedule), 73.x will become the new stable (.122 is the last 72, i guess).
