### PR TITLE
docs: Update links for official Windows build instructions

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -109,7 +109,7 @@ Source package files will appear under `build/`
 
 ## Windows
 
-Google only supports [Windows 7 x64 or newer](https://chromium.googlesource.com/chromium/src/+/64.0.3282.168/docs/windows_build_instructions.md#system-requirements). These instructions are tested on Windows 7 Professional x64.
+Google only supports [Windows 7 x64 or newer](https://chromium.googlesource.com/chromium/src/+/72.0.3626.122/docs/windows_build_instructions.md#system-requirements). These instructions are tested on Windows 7 Professional x64.
 
 NOTE: The default configuration will build 64-bit binaries for maximum security (TODO: Link some explanation). This can be changed to 32-bit by following the instructions in `build.py`
 
@@ -117,9 +117,9 @@ NOTE: The default configuration will build 64-bit binaries for maximum security 
 
 #### Setting up Visual Studio
 
-[Follow the official Windows build instructions](https://chromium.googlesource.com/chromium/src/+/64.0.3282.168/docs/windows_build_instructions.md#visual-studio).
+[Follow the official Windows build instructions](https://chromium.googlesource.com/chromium/src/+/72.0.3626.122/docs/windows_build_instructions.md#visual-studio).
 
-**IMPORTANT**: According to [a Chromium developer in Google Groups](https://groups.google.com/a/chromium.org/d/msg/chromium-dev/PsqFiJ-j5B4/9wO3wflWCQAJ), due to bugs in the 10.0.16299.15 SDK (that comes with Visual Studio 2017 as of February 2018) *will not work* to build Chromium. The 10.0.15063 SDK must be downloaded and installed. This can be downloaded from the [Windows SDK Archive](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive).
+**IMPORTANT**: You must have the 10.0.17134 SDK (that exact version) downloaded and installed either through Visual Studio 2017 (install the "Desktop development with C++" component) or from the [Windows SDK Archive](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive).
 
 When installing the SDK, the "Debugging Tools for Windows" feature must be enabled. Visual Studio 2017 does not enable this by default, so it has to be added in by selecting "Modify" on the SDK entry in "Add or remove programs".
 


### PR DESCRIPTION
The current links to the official build instructions for Windows are for Chromium 64.0.3282.168. This pull request updates the links to those instructions for Chromium 72.0.3626.122 while telling users that they must download and install the 10.0.17134 SDK, not 10.0.10563 (as 10.0.17134 is the minimum for Chromium 72.0.3626.122).