### PR TITLE
Added flag to enable change tabs using scroll wheel.

### DIFF
--- a/patches/extra/ungoogled-chromium/add-flag-to-scroll-tabs.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-scroll-tabs.patch
@@ -1,0 +1,91 @@
+--- a/chrome/browser/about_flags.cc
++++ b/chrome/browser/about_flags.cc
+@@ -236,6 +236,16 @@ const FeatureEntry::Choice kShowAvatarButtonChoices[] = {
+      "never"}
+ };
+ 
++const FeatureEntry::Choice kScrollEventChangesTab[] = {
++    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
++    {"Always",
++     "scroll-tabs",
++     "always"},
++    {"Never",
++     "scroll-tabs",
++     "never"}
++};
++
+ const FeatureEntry::Choice kTouchEventFeatureDetectionChoices[] = {
+     {flags_ui::kGenericExperimentChoiceDisabled, "", ""},
+     {flags_ui::kGenericExperimentChoiceEnabled,
+@@ -4252,6 +4262,11 @@ const FeatureEntry kFeatureEntries[] = {
+      kOsAndroid, FEATURE_VALUE_TYPE(safe_browsing::kUseLocalBlacklistsV2)},
+ #endif  // defined(OS_ANDROID)
+ 
++    {"scroll-tabs",
++     "Scroll switches tab",
++     "Switch to the left/right tab if the wheel-scroll happens over the tabstrip, or the empty space beside the tabstrip.", kOsDesktop,
++     MULTI_VALUE_TYPE(kScrollEventChangesTab)},
++
+ #if defined(OS_CHROMEOS)
+     {"enable-native-google-assistant",
+      flag_descriptions::kEnableGoogleAssistantName,
+--- a/chrome/browser/ui/views/frame/browser_root_view.cc
++++ b/chrome/browser/ui/views/frame/browser_root_view.cc
+@@ -7,6 +7,7 @@
+ #include <cmath>
+ #include <string>
+ 
++#include "base/command_line.h"
+ #include "base/metrics/user_metrics.h"
+ #include "base/task/post_task.h"
+ #include "chrome/browser/autocomplete/autocomplete_classifier_factory.h"
+@@ -90,6 +91,18 @@ int GetDropEffect(const ui::DropTargetEvent& event, const GURL& url) {
+   return ui::DragDropTypes::DRAG_MOVE;
+ }
+ 
++bool ShouldScrollChangesTab() {
++  const std::string flag_value =
++    base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("scroll-tabs");
++
++  if (flag_value == "always")
++    return true;
++  else if (flag_value == "never")
++    return false;
++
++  return browser_defaults::kScrollEventChangesTab;
++}
++
+ }  // namespace
+ 
+ BrowserRootView::DropInfo::DropInfo() = default;
+@@ -107,7 +120,9 @@ BrowserRootView::BrowserRootView(BrowserView* browser_view,
+                                  views::Widget* widget)
+     : views::internal::RootView(widget),
+       browser_view_(browser_view),
+-      weak_ptr_factory_(this) {}
++      weak_ptr_factory_(this) {
++        scroll_event_changes_tab_ = ShouldScrollChangesTab();
++}
+ 
+ BrowserRootView::~BrowserRootView() = default;
+ 
+@@ -240,7 +255,7 @@ const char* BrowserRootView::GetClassName() const {
+ }
+ 
+ bool BrowserRootView::OnMouseWheel(const ui::MouseWheelEvent& event) {
+-  if (browser_defaults::kScrollEventChangesTab) {
++  if (scroll_event_changes_tab_) {
+     // Switch to the left/right tab if the wheel-scroll happens over the
+     // tabstrip, or the empty space beside the tabstrip.
+     views::View* hit_view = GetEventHandlerForPoint(event.location());
+--- a/chrome/browser/ui/views/frame/browser_root_view.h
++++ b/chrome/browser/ui/views/frame/browser_root_view.h
+@@ -125,6 +125,8 @@ class BrowserRootView : public views::internal::RootView {
+   int scroll_remainder_x_ = 0;
+   int scroll_remainder_y_ = 0;
+ 
++  bool scroll_event_changes_tab_ = false;
++
+   std::unique_ptr<DropInfo> drop_info_;
+ 
+   base::WeakPtrFactory<BrowserRootView> weak_ptr_factory_;

--- a/patches/series
+++ b/patches/series
@@ -90,3 +90,4 @@ extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch
 extra/google/prevent-vsyncparameters-log-flooding.patch
+extra/ungoogled-chromium/add-flag-to-scroll-tabs.patch


### PR DESCRIPTION
Unfortunately, there is a lack of such a useful feature as switching tabs with the mouse wheel.
Fortunately, this feature is already implemented in the chromium code.
So, this PR adds a setting in the `chrome://flags` section to enable (or strongly disable) this feature.

In the code.
```
#if defined(OS_LINUX) && !defined(OS_CHROMEOS)
```
This is condition when `kScrollEventChangesTab` is `true`. So this behaviour will be with `default` value of flag. Other values of flag (`always` and `never`) will ignore this condition and will set the appropriate boolean value. 