### PR TITLE
Enabled ability to use Paste and Go with wheel on New Tab Button.

### DIFF
--- a/patches/extra/ungoogled-chromium/enable-paste-and-go-new-tab-button.patch
+++ b/patches/extra/ungoogled-chromium/enable-paste-and-go-new-tab-button.patch
@@ -1,0 +1,31 @@
+--- a/chrome/browser/ui/views/tabs/new_tab_button.cc
++++ b/chrome/browser/ui/views/tabs/new_tab_button.cc
+@@ -64,10 +64,8 @@ const gfx::Size NewTabButton::kButtonSize{28, 28};
+ NewTabButton::NewTabButton(TabStrip* tab_strip, views::ButtonListener* listener)
+     : views::ImageButton(listener), tab_strip_(tab_strip) {
+   set_animate_on_state_change(true);
+-#if defined(OS_LINUX) && !defined(OS_CHROMEOS)
+   set_triggerable_event_flags(triggerable_event_flags() |
+                               ui::EF_MIDDLE_MOUSE_BUTTON);
+-#endif
+ 
+   // Initialize the ink drop mode for a ripple highlight on button press.
+   ink_drop_container_ = new views::InkDropContainerView();
+--- a/chrome/browser/ui/views/tabs/tab_strip.cc
++++ b/chrome/browser/ui/views/tabs/tab_strip.cc
+@@ -2662,15 +2662,12 @@ void TabStrip::ButtonPressed(views::Button* sender, const ui::Event& event) {
+     if (event.IsMouseEvent()) {
+       const ui::MouseEvent& mouse = static_cast<const ui::MouseEvent&>(event);
+       if (mouse.IsOnlyMiddleMouseButton()) {
+-        if (ui::Clipboard::IsSupportedClipboardType(
+-                ui::CLIPBOARD_TYPE_SELECTION)) {
+           ui::Clipboard* clipboard = ui::Clipboard::GetForCurrentThread();
+           CHECK(clipboard);
+           base::string16 clipboard_text;
+           clipboard->ReadText(ui::CLIPBOARD_TYPE_SELECTION, &clipboard_text);
+           if (!clipboard_text.empty())
+             controller_->CreateNewTabWithLocation(clipboard_text);
+-        }
+         return;
+       }
+     }

--- a/patches/series
+++ b/patches/series
@@ -84,6 +84,7 @@ extra/ungoogled-chromium/add-suggestions-url-field.patch
 extra/ungoogled-chromium/add-flag-to-hide-crashed-bubble.patch
 extra/ungoogled-chromium/default-to-https-scheme.patch
 extra/ungoogled-chromium/add-flag-to-scroll-tabs.patch
+extra/ungoogled-chromium/enable-paste-and-go-new-tab-button.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch


### PR DESCRIPTION
Another feature that is hidden from non-linux users is the `Paste and Go` with wheel on the New Tab Button.
It would be cool to have this feature on other platforms.
I dont see any reason to add setting in `chrome://flags` for it — if someone does not need this function, then just do not use it, still pressing the New Tab Button with wheel did nothing before.

![image](https://user-images.githubusercontent.com/4051126/56578944-84afd280-65d7-11e9-89cc-386101319720.gif)
