### PR TITLE
Some Android-specific fixes which are beneficial/neutral for all variants

### DIFF
--- a/devutils/update_lists.py
+++ b/devutils/update_lists.py
@@ -90,6 +90,9 @@ DOMAIN_EXCLUDE_PREFIXES = [
     'net/http/transport_security_state_static.json',
     # Exclusions for Visual Studio Project generation with GN (PR #445)
     'tools/gn/tools/gn/visual_studio_writer.cc',
+    # Exclusions for files covered with other patches/unnecessary
+    'components/search_engines/prepopulated_engines.json',
+    'third_party/blink/renderer/core/dom/document.cc',
 ]
 
 # pathlib.Path.match() patterns to include in domain substitution

--- a/domain_regex.list
+++ b/domain_regex.list
@@ -1,5 +1,5 @@
 fonts(\\*?)\.googleapis(\\*?)\.com#f0ntz\g<1>.9oo91e8p1\g<2>.qjz9zk
-google([A-Za-z\-]*?\\*?)\.com#9oo91e\g<1>.qjz9zk
+google([A-Za-z\-]*?\\*?)\.com(?!mon)#9oo91e\g<1>.qjz9zk
 gstatic([A-Za-z\-]*?\\*?)\.com#95tat1c\g<1>.qjz9zk
 chrome([A-Za-z\-]*?\\*?)\.com#ch40me\g<1>.qjz9zk
 chromium([A-Za-z\-]*?\\*?)\.org#ch40m1um\g<1>.qjz9zk
@@ -16,5 +16,5 @@ beacons([1-9]?\\*?)\.gvt([1-9]?\\*?)\.com#b3ac0n2\g<1>.9vt\g<2>.qjz9zk
 ggpht(\\*?)\.com#99pht\g<1>.qjz9zk
 microsoft(\\*?)\.com#m1cr050ft\g<1>.qjz9zk
 1e100(\\*?)\.net#l3lOO\g<1>.qjz9zk
-android(\\*?)\.com#8n6r01d\g<1>.qjz9zk
+(?<!http://schemas.)android(\\*?)\.com#8n6r01d\g<1>.qjz9zk
 goo\.gl#goo.gl.qjz9zk

--- a/domain_substitution.list
+++ b/domain_substitution.list
@@ -4771,7 +4771,6 @@ third_party/blink/renderer/core/dom/class_collection.cc
 third_party/blink/renderer/core/dom/class_collection.h
 third_party/blink/renderer/core/dom/comment.idl
 third_party/blink/renderer/core/dom/container_node.cc
-third_party/blink/renderer/core/dom/document.cc
 third_party/blink/renderer/core/dom/document_test.cc
 third_party/blink/renderer/core/dom/dom_implementation.idl
 third_party/blink/renderer/core/dom/element.cc

--- a/domain_substitution.list
+++ b/domain_substitution.list
@@ -2831,7 +2831,6 @@ components/safe_search_api/stub_url_checker.cc
 components/safe_search_api/url_checker_unittest.cc
 components/search_engines/default_search_policy_handler_unittest.cc
 components/search_engines/keyword_table_unittest.cc
-components/search_engines/prepopulated_engines.json
 components/search_engines/template_url.cc
 components/search_engines/template_url.h
 components/search_engines/template_url_data_unittest.cc


### PR DESCRIPTION
This PR contains a commit to make the first part of https://github.com/ungoogled-software/ungoogled-chromium-android/blob/master/patches/android-prune-domain-fix.patch redundant and another commit to not replace google.com in the prepopulated search engines list.