### PR TITLE
Enable DoH for all platforms.

### DIFF
--- a/patches/extra/ungoogled-chromium/enable-DoH.patch
+++ b/patches/extra/ungoogled-chromium/enable-DoH.patch
@@ -1,0 +1,12 @@
+--- a/chrome/browser/about_flags.cc
++++ b/chrome/browser/about_flags.cc
+@@ -4528,8 +4528,7 @@ const FeatureEntry kFeatureEntries[] = {
+      FEATURE_VALUE_TYPE(blink::features::kDecodeLossyWebPImagesToYUV)},
+ 
+     {"dns-over-https", flag_descriptions::kDnsOverHttpsName,
+-     flag_descriptions::kDnsOverHttpsDescription,
+-     kOsMac | kOsWin | kOsCrOS | kOsAndroid,
++     flag_descriptions::kDnsOverHttpsDescription, kOsAll,
+      FEATURE_VALUE_TYPE(features::kDnsOverHttps)},
+ 
+ #if defined(OS_ANDROID)

--- a/patches/series
+++ b/patches/series
@@ -82,6 +82,7 @@ extra/ungoogled-chromium/add-flag-to-hide-crashed-bubble.patch
 extra/ungoogled-chromium/default-to-https-scheme.patch
 extra/ungoogled-chromium/add-flag-to-scroll-tabs.patch
 extra/ungoogled-chromium/enable-paste-and-go-new-tab-button.patch
+extra/ungoogled-chromium/enable-DoH.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch


### PR DESCRIPTION
Note that DoH is still optional, this just enables the user to choose
their own DoH.

---
Untested as in I can't compile this to find out if it works, but this worked on Chromium 74-77 before the upstream developers hid this behind a flag.

Edit: Redacted after realizing this https://github.com/Eloston/ungoogled-chromium/issues/833#issuecomment-551322443