### PR TITLE
Guix is back

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Also, ungoogled-chromium is available in several **software repositories**:
 * Gentoo Linux: 
   * [`::pf4public`](https://github.com/PF4Public/gentoo-overlay) overlay maintains an *unofficial*  [`ungoogled-chromium`](https://github.com/PF4Public/gentoo-overlay/tree/master/www-client/ungoogled-chromium) ebuild
   * [`::chaoslab`](https://gitlab.com/chaoslab/chaoslab-overlay) overlay maintains an *unofficial*  [`ungoogled-chromium`](https://gitlab.com/chaoslab/chaoslab-overlay/tree/master/www-client/ungoogled-chromium) ebuild (stalled)
-* GNU Guix: Available as `ungoogled-chromium` [(abandoned)](https://lists.gnu.org/archive/html/guix-devel/2019-10/msg00576.html).
+* GNU Guix: Available as `ungoogled-chromium`.
 * macOS cask: Available as `eloston-chromium`. Install (via [Homebrew](https://brew.sh/)) by running: `brew cask fetch eloston-chromium` and then `brew cask install eloston-chromium`
 
 ## Source Code


### PR DESCRIPTION
https://guix.gnu.org/packages/ungoogled-chromium-78.0.3904.97-0.acaf163/

\o/