### PR TITLE
Removed Arch Linux untrusted AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ These binaries are known as **contributor binaries**.
 Also, ungoogled-chromium is available in several **software repositories**:
 
 * Arch Linux: [Available in AUR as `ungoogled-chromium`](https://aur.archlinux.org/packages/ungoogled-chromium/)
-    * NOTE: `ungoogled-chromium-bin` is *not* officially part of ungoogled-chromium. Please submit all issues to the maintainer of the PKGBUILD.
 * Fedora: Available in [RPM Fusion](https://rpmfusion.org) as `chromium-browser-privacy`.
 * Gentoo Linux: 
   * [`::pf4public`](https://github.com/PF4Public/gentoo-overlay) overlay maintains an *unofficial*  [`ungoogled-chromium`](https://github.com/PF4Public/gentoo-overlay/tree/master/www-client/ungoogled-chromium) ebuild


### PR DESCRIPTION
The `ungoogled-chromium-bin` package should have not been added here from the beginning, its not only an unofficial package but also very suspicious that doesn't download from the official built binaries but from the package owner's link itself.

the package creator made the download link to his own path: `download.opensuse.org/repositories/home:/justkidding:/arch/standard/x86_64/ungoogled-chromium-$pkgver-1-x86_64.pkg.tar.xz` which give him freedom to do anything with it.

`ungoogled-chromium-bin` is now deleted from the AUR but it can be recreated by other users so its better to be deleted from README.