### PR TITLE
Remove lines causing Android build to fail

### DIFF
--- a/patches/core/ungoogled-chromium/remove-unused-preferences-fields.patch
+++ b/patches/core/ungoogled-chromium/remove-unused-preferences-fields.patch
@@ -601,22 +601,6 @@
  
  namespace policy {
  BrowserSigninPolicyHandler::BrowserSigninPolicyHandler(Schema chrome_schema)
-@@ -49,7 +48,6 @@ void BrowserSigninPolicyHandler::ApplyPo
-             // The new kSigninAllowedOnNextStartup pref is only used on Desktop.
-             // Keep the old kSigninAllowed pref for Android until the policy is
-             // fully deprecated in M71 and can be removed.
--            prefs::kSigninAllowed,
- #else
-             prefs::kSigninAllowedOnNextStartup,
- #endif
-@@ -61,7 +59,6 @@ void BrowserSigninPolicyHandler::ApplyPo
-             // The new kSigninAllowedOnNextStartup pref is only used on Desktop.
-             // Keep the old kSigninAllowed pref for Android until the policy is
-             // fully deprecated in M71 and can be removed.
--            prefs::kSigninAllowed,
- #else
-             prefs::kSigninAllowedOnNextStartup,
- #endif
 --- a/chrome/browser/policy/configuration_policy_handler_list_factory.cc
 +++ b/chrome/browser/policy/configuration_policy_handler_list_factory.cc
 @@ -64,9 +64,7 @@
@@ -745,14 +729,6 @@
    // Handlers for policies with embedded JSON strings. These handlers are very
    // lenient - as long as the root value is of the right type, they only display
    // warnings and never reject the policy value.
-@@ -1476,7 +1402,6 @@ std::unique_ptr<ConfigurationPolicyHandl
-       // The new kSigninAllowedOnNextStartup pref is only used on Desktop.
-       // Keep the old kSigninAllowed pref for Android until the policy is
-       // fully deprecated in M71 and can be removed.
--      prefs::kSigninAllowed,
- #else
-       prefs::kSigninAllowedOnNextStartup,
- #endif
 --- a/chrome/browser/prefs/browser_prefs.cc
 +++ b/chrome/browser/prefs/browser_prefs.cc
 @@ -124,7 +124,6 @@

--- a/patches/core/ungoogled-chromium/remove-unused-preferences-fields.patch
+++ b/patches/core/ungoogled-chromium/remove-unused-preferences-fields.patch
@@ -601,6 +601,40 @@
  
  namespace policy {
  BrowserSigninPolicyHandler::BrowserSigninPolicyHandler(Schema chrome_schema)
+@@ -41,32 +40,9 @@ void BrowserSigninPolicyHandler::ApplyPolicySettings(const PolicyMap& policies,
+       case BrowserSigninMode::kForced:
+ #if !defined(OS_LINUX)
+         prefs->SetValue(prefs::kForceBrowserSignin, base::Value(true));
+-#endif
+-        FALLTHROUGH;
+-      case BrowserSigninMode::kEnabled:
+-        prefs->SetValue(
+-#if defined(OS_ANDROID)
+-            // The new kSigninAllowedOnNextStartup pref is only used on Desktop.
+-            // Keep the old kSigninAllowed pref for Android until the policy is
+-            // fully deprecated in M71 and can be removed.
+-            prefs::kSigninAllowed,
+-#else
+-            prefs::kSigninAllowedOnNextStartup,
+-#endif
+-            base::Value(true));
+-        break;
+-      case BrowserSigninMode::kDisabled:
+-        prefs->SetValue(
+-#if defined(OS_ANDROID)
+-            // The new kSigninAllowedOnNextStartup pref is only used on Desktop.
+-            // Keep the old kSigninAllowed pref for Android until the policy is
+-            // fully deprecated in M71 and can be removed.
+-            prefs::kSigninAllowed,
+ #else
+-            prefs::kSigninAllowedOnNextStartup,
++        ;
+ #endif
+-            base::Value(false));
+-        break;
+     }
+   }
+ }
 --- a/chrome/browser/policy/configuration_policy_handler_list_factory.cc
 +++ b/chrome/browser/policy/configuration_policy_handler_list_factory.cc
 @@ -64,9 +64,7 @@
@@ -729,6 +763,24 @@
    // Handlers for policies with embedded JSON strings. These handlers are very
    // lenient - as long as the root value is of the right type, they only display
    // warnings and never reject the policy value.
+@@ -1470,17 +1396,6 @@ std::unique_ptr<ConfigurationPolicyHandlerList> BuildHandlerList(
+   signin_legacy_policies.push_back(std::make_unique<SimplePolicyHandler>(
+       key::kForceBrowserSignin, prefs::kForceBrowserSignin,
+       base::Value::Type::BOOLEAN));
+-  signin_legacy_policies.push_back(std::make_unique<SimplePolicyHandler>(
+-      key::kSigninAllowed,
+-#if defined(OS_ANDROID)
+-      // The new kSigninAllowedOnNextStartup pref is only used on Desktop.
+-      // Keep the old kSigninAllowed pref for Android until the policy is
+-      // fully deprecated in M71 and can be removed.
+-      prefs::kSigninAllowed,
+-#else
+-      prefs::kSigninAllowedOnNextStartup,
+-#endif
+-      base::Value::Type::BOOLEAN));
+   handlers->AddHandler(std::make_unique<LegacyPoliciesDeprecatingPolicyHandler>(
+       std::move(signin_legacy_policies),
+       std::make_unique<BrowserSigninPolicyHandler>(chrome_schema)));
 --- a/chrome/browser/prefs/browser_prefs.cc
 +++ b/chrome/browser/prefs/browser_prefs.cc
 @@ -124,7 +124,6 @@


### PR DESCRIPTION
The removed lines in the patch will lead to wrong number of arguments when building for Android.