### PR TITLE
[Patches] [Use Local Devtools Files] Don't set any module as generated_remote_modules

### DIFF
--- a/patches/core/ungoogled-chromium/use-local-devtools-files.patch
+++ b/patches/core/ungoogled-chromium/use-local-devtools-files.patch
@@ -5,7 +5,21 @@
 
 --- a/third_party/devtools-frontend/src/BUILD.gn
 +++ b/third_party/devtools-frontend/src/BUILD.gn
-@@ -1855,7 +1855,6 @@ devtools_frontend_resources_deps = [
+@@ -1783,12 +1783,7 @@ generated_non_autostart_non_remote_modul
+   "$resources_out_dir/workspace_diff/workspace_diff_module.js",
+ ]
+ 
+-generated_remote_modules = [
+-  "$resources_out_dir/accessibility/accessibility_module.js",
+-  "$resources_out_dir/audits_worker/audits_worker_module.js",
+-  "$resources_out_dir/dagre_layout/dagre_layout_module.js",
+-  "$resources_out_dir/emulated_devices/emulated_devices_module.js",
+-]
++generated_remote_modules = []
+ 
+ generated_test_modules = [
+   "$resources_out_dir/accessibility_test_runner/accessibility_test_runner_module.js",
+@@ -1856,7 +1851,6 @@ devtools_frontend_resources_deps = [
    ":copy_htaccess",
    ":copy_inspector_images",
    ":copy_lighthouse_locale_files",
@@ -13,7 +27,7 @@
    ":devtools_extension_api",
    ":frontend_protocol_sources",
    ":supported_css_properties",
-@@ -1938,7 +1937,6 @@ action("generate_devtools_grd") {
+@@ -1939,7 +1933,6 @@ action("generate_devtools_grd") {
        generated_scripts + generated_worker_bundles +
        [
          "$resources_out_dir/devtools_extension_api.js",

--- a/patches/core/ungoogled-chromium/use-local-devtools-files.patch
+++ b/patches/core/ungoogled-chromium/use-local-devtools-files.patch
@@ -5,7 +5,7 @@
 
 --- a/third_party/devtools-frontend/src/BUILD.gn
 +++ b/third_party/devtools-frontend/src/BUILD.gn
-@@ -1783,12 +1783,7 @@ generated_non_autostart_non_remote_modul
+@@ -1782,12 +1782,7 @@ generated_non_autostart_non_remote_modul
    "$resources_out_dir/workspace_diff/workspace_diff_module.js",
  ]
  
@@ -19,7 +19,7 @@
  
  generated_test_modules = [
    "$resources_out_dir/accessibility_test_runner/accessibility_test_runner_module.js",
-@@ -1856,7 +1851,6 @@ devtools_frontend_resources_deps = [
+@@ -1855,7 +1850,6 @@ devtools_frontend_resources_deps = [
    ":copy_htaccess",
    ":copy_inspector_images",
    ":copy_lighthouse_locale_files",
@@ -27,7 +27,7 @@
    ":devtools_extension_api",
    ":frontend_protocol_sources",
    ":supported_css_properties",
-@@ -1939,7 +1933,6 @@ action("generate_devtools_grd") {
+@@ -1938,7 +1932,6 @@ action("generate_devtools_grd") {
        generated_scripts + generated_worker_bundles +
        [
          "$resources_out_dir/devtools_extension_api.js",


### PR DESCRIPTION
As mentioned in https://github.com/Eloston/ungoogled-chromium/pull/942, generating Lighthouse reports via the DevTools' Audits panel has been broken due to trying to remotely fetch `audits_worker_module.js`.

This patch drops all modules from `generated_remote_modules`, however I'm not positive if the three other modules really need to be dropped or not. -- but from scanning `third_party/devtools-frontend/scripts/build/build_release_applications.py` it looked like it was dropping any remote module from being bundled (disclaimer: not a Python dev).  Let me know if the changes need to be revised to only drop `$resources_out_dir/audits_worker/audits_worker_module.js` from `generated_remote_modules` in `third_party/devtools-frontend/src/BUILD.gn`.

Sidebar: Upstream has renamed "Audits" to "Lighthouse" and the directory structure has changed https://chromium.googlesource.com/devtools/devtools-frontend/+/88fd132a05e848d2ae13da9bacff4a6ce5863a17/front_end/ -- so this patch update will be stale relatively quickly

---

Edit: I updated this locally in my `ungoogled-chromium-archlinux` build and it applied the patch successfully for `80.0.3987.106` -- didn't even think to run the `validate_with_source` check, will update and push whatever required changes shortly