### PR TITLE
[Patches] [Use Local Devtools Files] Add generated_remote_modules to generated_non_autostart_non_remote_modules

### DIFF
--- a/patches/core/ungoogled-chromium/use-local-devtools-files.patch
+++ b/patches/core/ungoogled-chromium/use-local-devtools-files.patch
@@ -5,21 +5,25 @@
 
 --- a/third_party/devtools-frontend/src/BUILD.gn
 +++ b/third_party/devtools-frontend/src/BUILD.gn
-@@ -1782,12 +1782,7 @@ generated_non_autostart_non_remote_modul
+@@ -1780,15 +1780,14 @@ generated_non_autostart_non_remote_modul
+   "$resources_out_dir/timeline/timeline_module.js",
+   "$resources_out_dir/web_audio/web_audio_module.js",
    "$resources_out_dir/workspace_diff/workspace_diff_module.js",
+-]
+-
+-generated_remote_modules = [
+   "$resources_out_dir/accessibility/accessibility_module.js",
+   "$resources_out_dir/audits_worker/audits_worker_module.js",
+   "$resources_out_dir/dagre_layout/dagre_layout_module.js",
+   "$resources_out_dir/emulated_devices/emulated_devices_module.js",
  ]
  
--generated_remote_modules = [
--  "$resources_out_dir/accessibility/accessibility_module.js",
--  "$resources_out_dir/audits_worker/audits_worker_module.js",
--  "$resources_out_dir/dagre_layout/dagre_layout_module.js",
--  "$resources_out_dir/emulated_devices/emulated_devices_module.js",
--]
 +generated_remote_modules = []
- 
++
  generated_test_modules = [
    "$resources_out_dir/accessibility_test_runner/accessibility_test_runner_module.js",
-@@ -1855,7 +1850,6 @@ devtools_frontend_resources_deps = [
+   "$resources_out_dir/application_test_runner/application_test_runner_module.js",
+@@ -1855,7 +1854,6 @@ devtools_frontend_resources_deps = [
    ":copy_htaccess",
    ":copy_inspector_images",
    ":copy_lighthouse_locale_files",
@@ -27,7 +31,7 @@
    ":devtools_extension_api",
    ":frontend_protocol_sources",
    ":supported_css_properties",
-@@ -1938,7 +1932,6 @@ action("generate_devtools_grd") {
+@@ -1938,7 +1936,6 @@ action("generate_devtools_grd") {
        generated_scripts + generated_worker_bundles +
        [
          "$resources_out_dir/devtools_extension_api.js",


### PR DESCRIPTION
Was moving a little too fast throughout my local repos and made a mistake in #946 -- the `generated_remote_modules` need to be added to `generated_non_autostart_non_remote_modules` rather than being dropped completely. Apologizes for the slip-up!