### PR TITLE
Update maintainer's nickname for Ubuntu PPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Also, ungoogled-chromium is available in several **software repositories**:
 * Fedora: Available in [RPM Fusion](https://rpmfusion.org) as `chromium-browser-privacy`.
 * GNU Guix: Available as `ungoogled-chromium`.
 * Gentoo Linux: [`::pf4public`](https://github.com/PF4Public/gentoo-overlay) overlay maintains an *unofficial*  [`ungoogled-chromium`](https://github.com/PF4Public/gentoo-overlay/tree/master/www-client/ungoogled-chromium) ebuild
-* Ubuntu: [PPA (maintained by @ryu0)](https://launchpad.net/~braewoods/+archive/ubuntu/ungoogled-chromium)
+* Ubuntu: [PPA](https://launchpad.net/~braewoods/+archive/ubuntu/ungoogled-chromium) (maintained by [@braewoods](https://github.com/braewoods))
 * macOS cask: Available as `eloston-chromium`. Install (via [Homebrew](https://brew.sh/)) by running: `brew cask fetch eloston-chromium` and then `brew cask install eloston-chromium`
 
 ## Source Code


### PR DESCRIPTION
I've noticed that Ubuntu PPA maintainer's nickname is @braewoods, not @ryou. If it is, please, let me know.