### PR TITLE
Returned checkbox to remember association of app with URL Scheme.

### DIFF
--- a/patches/extra/ungoogled-chromium/enable-checkbox-external-protocol.patch
+++ b/patches/extra/ungoogled-chromium/enable-checkbox-external-protocol.patch
@@ -1,0 +1,12 @@
+# Return "Always open links of this type in the associated app" checkbox.
+
+--- a/chrome/browser/ui/browser_ui_prefs.cc
++++ b/chrome/browser/ui/browser_ui_prefs.cc
+@@ -135,6 +135,6 @@ void RegisterBrowserUserPrefs(user_prefs::PrefRegistrySyncable* registry) {
+   registry->RegisterBooleanPref(prefs::kUserFeedbackAllowed, true);
+   registry->RegisterBooleanPref(prefs::kAllowSyncXHRInPageDismissal, false);
+   registry->RegisterBooleanPref(
+-      prefs::kExternalProtocolDialogShowAlwaysOpenCheckbox, false);
++      prefs::kExternalProtocolDialogShowAlwaysOpenCheckbox, true);
+   registry->RegisterBooleanPref(prefs::kScreenCaptureAllowed, true);
+ }

--- a/patches/series
+++ b/patches/series
@@ -78,6 +78,7 @@ extra/ungoogled-chromium/add-flag-to-hide-crashed-bubble.patch
 extra/ungoogled-chromium/default-to-https-scheme.patch
 extra/ungoogled-chromium/add-flag-to-scroll-tabs.patch
 extra/ungoogled-chromium/enable-paste-and-go-new-tab-button.patch
+extra/ungoogled-chromium/enable-checkbox-external-protocol.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch


### PR DESCRIPTION
After [this commit](https://github.com/chromium/chromium/commit/9f8e95c96f5de02811f5d3cbc74da72714498533) the "Always open" checkbox became controlled by an additional policy that has `false` as a default value. 
So, regular users who don't want to deal with the policies on their OS can no longer remember opening external applications and must always make an extra click.
This simple PR adds a new patch file that replaces `false` default value with `true` and returns the previous behaviour.

![image](https://user-images.githubusercontent.com/4051126/79681302-e7a36c00-8221-11ea-84bd-0543778fafb8.png)
