### PR TITLE
Add patch for Bookmark-Bar on New-Tab-Page

### DIFF
--- a/patches/extra/ungoogled-chromium/add-flag-for-bookmark-bar-ntp.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-bookmark-bar-ntp.patch
@@ -1,0 +1,52 @@
+--- a/chrome/browser/about_flags.cc
++++ b/chrome/browser/about_flags.cc
+@@ -273,6 +273,13 @@ const FeatureEntry::Choice kShowAvatarBu
+      "never"}
+ };
+ 
++const FeatureEntry::Choice kBookmarkBarNewTab[] = {
++    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
++    {"Never",
++     "bookmark-bar-ntp",
++     "never"},
++};
++
+ const FeatureEntry::Choice kScrollEventChangesTab[] = {
+     {flags_ui::kGenericExperimentChoiceDefault, "", ""},
+     {"Always",
+@@ -3968,6 +3975,11 @@ const FeatureEntry kFeatureEntries[] = {
+      "Switch to the left/right tab if the wheel-scroll happens over the tabstrip, or the empty space beside the tabstrip.", kOsDesktop,
+      MULTI_VALUE_TYPE(kScrollEventChangesTab)},
+ 
++    {"bookmark-bar-ntp",
++     "Bookmark Bar on New-Tab-Page",
++     "Disable the Bookmark Bar on the New-Tab-Page", kOsDesktop,
++     MULTI_VALUE_TYPE(kBookmarkBarNewTab)},
++
+ #if defined(OS_CHROMEOS)
+     {"enable-zero-state-suggestions",
+      flag_descriptions::kEnableZeroStateSuggestionsName,
+--- a/chrome/browser/ui/bookmarks/bookmark_tab_helper.cc
++++ b/chrome/browser/ui/bookmarks/bookmark_tab_helper.cc
+@@ -4,6 +4,7 @@
+ 
+ #include "chrome/browser/ui/bookmarks/bookmark_tab_helper.h"
+ 
++#include "base/command_line.h"
+ #include "base/observer_list.h"
+ #include "build/build_config.h"
+ #include "chrome/browser/bookmarks/bookmark_model_factory.h"
+@@ -71,10 +72,12 @@ bool BookmarkTabHelper::ShouldShowBookma
+       !prefs->GetBoolean(bookmarks::prefs::kShowBookmarkBar))
+     return false;
+ 
++  const std::string flag_value =
++    base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("bookmark-bar-ntp");
+   // The bookmark bar is only shown on the NTP if the user
+   // has added something to it.
+   return IsNTP(web_contents()) && bookmark_model_ &&
+-         bookmark_model_->HasBookmarks();
++         bookmark_model_->HasBookmarks() && (flag_value != "never");
+ }
+ 
+ void BookmarkTabHelper::AddObserver(BookmarkTabHelperObserver* observer) {

--- a/patches/series
+++ b/patches/series
@@ -81,6 +81,7 @@ extra/ungoogled-chromium/add-flag-to-scroll-tabs.patch
 extra/ungoogled-chromium/enable-paste-and-go-new-tab-button.patch
 extra/ungoogled-chromium/enable-checkbox-external-protocol.patch
 extra/ungoogled-chromium/add-flag-for-pdf-plugin-name.patch
+extra/ungoogled-chromium/add-flag-for-bookmark-bar-ntp.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch


### PR DESCRIPTION
I really dislike the Bookmark-Bar, since it takes up more space than necessary.
I only toggle it when I really need it, since I still keep some Bookmarklets (For installing chrome store addons, etc.).
Not being able to toggle it on the new-tab-page was quite annoying for me.

This patch makes the Bookmark-Bar toggleable on the NTP (Maybe the flags description is a little confusing).
I hope I didn't do anything wrong, since this is my first time modifying the chromium source code.

![13:14:09](https://user-images.githubusercontent.com/44272603/86772259-f6950000-c053-11ea-8dab-a64001f545c7.png)
![13:08:20](https://user-images.githubusercontent.com/44272603/86771803-25f73d00-c053-11ea-9ed5-0c6e1c06635e.png)