### PR TITLE
Added ability to always open dev context menu on reload button.

### DIFF
--- a/patches/extra/ungoogled-chromium/enable-menu-on-reload-button.patch
+++ b/patches/extra/ungoogled-chromium/enable-menu-on-reload-button.patch
@@ -1,0 +1,13 @@
+# Add ability to always open dev context menu on reload button.
+
+--- a/chrome/browser/ui/views/toolbar/reload_button.h
++++ b/chrome/browser/ui/views/toolbar/reload_button.h
+@@ -42,7 +42,7 @@ class ReloadButton : public ToolbarButton,
+   void ChangeMode(Mode mode, bool force);
+ 
+   // Enable reload drop-down menu.
+-  void set_menu_enabled(bool enable) { menu_enabled_ = enable; }
++  void set_menu_enabled(bool enable) { menu_enabled_ = true; }
+ 
+   void SetColors(SkColor normal_color, SkColor disabled_color);
+ 

--- a/patches/series
+++ b/patches/series
@@ -82,6 +82,7 @@ extra/ungoogled-chromium/add-flag-for-pdf-plugin-name.patch
 extra/ungoogled-chromium/add-flag-for-bookmark-bar-ntp.patch
 extra/ungoogled-chromium/enable-default-prefetch-privacy-changes.patch
 extra/ungoogled-chromium/enable-default-reduced-referrer-granularity.patch
+extra/ungoogled-chromium/enable-menu-on-reload-button.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch


### PR DESCRIPTION
This small PR adds ability to use the dev context menu on the reload button even in a non-dev mode.
The reload button does not have any context menu by default, so I don't see any reason to complicate my commit with a command-line flag.
<details>

![image](https://user-images.githubusercontent.com/4051126/90318959-b66f4a00-df3c-11ea-8b37-a150b9066c49.png)

</details>