### PR TITLE
Disable DIAL repeating discovery

### DIFF
--- a/patches/extra/ungoogled-chromium/disable-dial-repeating-discovery.patch
+++ b/patches/extra/ungoogled-chromium/disable-dial-repeating-discovery.patch
@@ -1,0 +1,16 @@
+# Disables the dial registry's repeating discovery timer
+# This caused unnecessary SSDP network spam
+
+--- a/chrome/browser/media/router/discovery/dial/dial_registry.cc
++++ b/chrome/browser/media/router/discovery/dial/dial_registry.cc
+@@ -196,10 +196,6 @@
+ 
+   dial_ = CreateDialService();
+   dial_->AddObserver(this);
+-  DoDiscovery();
+-  repeating_timer_.reset(new base::RepeatingTimer());
+-  repeating_timer_->Start(FROM_HERE, refresh_interval_delta_, this,
+-                          &DialRegistry::DoDiscovery);
+ }
+ 
+ void DialRegistry::DoDiscovery() {

--- a/patches/series
+++ b/patches/series
@@ -84,6 +84,7 @@ extra/ungoogled-chromium/enable-default-prefetch-privacy-changes.patch
 extra/ungoogled-chromium/enable-default-reduced-referrer-granularity.patch
 extra/ungoogled-chromium/enable-menu-on-reload-button.patch
 extra/ungoogled-chromium/add-flag-for-omnibox-autocomplete-filtering.patch
+extra/ungoogled-chromium/disable-dial-repeating-discovery.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch


### PR DESCRIPTION
The DIAL registry has a timer set to send out SSDP broadcasts every two minutes.  
This removes the timer to prevent network spam.  
Fixes #991
