### PR TITLE
Block request attempts

### DIFF
--- a/patches/core/ungoogled-chromium/block-requests.patch
+++ b/patches/core/ungoogled-chromium/block-requests.patch
@@ -1,0 +1,59 @@
+## Prevent request attempts
+# chrome://discards/ attempts to use d3 to display the graph
+--- a/chrome/browser/resources/discards/graph_doc_template.html
++++ b/chrome/browser/resources/discards/graph_doc_template.html
+@@ -78,10 +78,6 @@
+       }
+ 
+     </style>
+-  <script src="https://ajax.googleapis.com/ajax/libs/d3js/5.7.0/d3.min.js"
+-      integrity="sha384-HL96dun1KbYEq6UT/ZlsspAODCyQ+Zp4z318ajUPBPSMzy5dvxl6ziwmnil8/Cpd"
+-      crossorigin="anonymous">
+-  </script>
+   <script type="application/javascript">
+ ${javascript_file}
+   </script>
+# New tab page tries to download background images
+--- a/chrome/browser/search/background/ntp_background_service.cc
++++ b/chrome/browser/search/background/ntp_background_service.cc
+@@ -61,6 +61,7 @@
+ }
+ 
+ void NtpBackgroundService::FetchCollectionInfo() {
++  return;
+   if (collections_loader_ != nullptr)
+     return;
+   collection_error_info_.ClearError();
+# New tab page attempts to download the 'One Google' bar
+--- a/chrome/browser/search/one_google_bar/one_google_bar_loader_impl.cc
++++ b/chrome/browser/search/one_google_bar/one_google_bar_loader_impl.cc
+@@ -276,6 +276,7 @@
+ OneGoogleBarLoaderImpl::~OneGoogleBarLoaderImpl() = default;
+ 
+ void OneGoogleBarLoaderImpl::Load(OneGoogleCallback callback) {
++  return;
+   callbacks_.push_back(std::move(callback));
+ 
+   // Note: If there is an ongoing request, abandon it. It's possible that
+# New tab page attempts to load promos
+--- a/chrome/browser/search/promos/promo_service.cc
++++ b/chrome/browser/search/promos/promo_service.cc
+@@ -131,6 +131,7 @@
+ PromoService::~PromoService() = default;
+ 
+ void PromoService::Refresh() {
++  return;
+   if (extensions::ShouldShowExtensionsCheckupPromo(profile_)) {
+     ServeExtensionCheckupPromo();
+     return;
+# Attempts to check for updates even wtih autoupdate disabled
+--- a/components/update_client/update_checker.cc
++++ b/components/update_client/update_checker.cc
+@@ -126,6 +126,7 @@
+     const base::flat_map<std::string, std::string>& additional_attributes,
+     bool enabled_component_updates,
+     UpdateCheckCallback update_check_callback) {
++  return;
+   DCHECK(thread_checker_.CalledOnValidThread());
+ 
+   ids_checked_ = ids_checked;

--- a/patches/series
+++ b/patches/series
@@ -33,6 +33,7 @@ core/ungoogled-chromium/disable-mei-preload.patch
 core/ungoogled-chromium/fix-building-without-safebrowsing.patch
 core/ungoogled-chromium/remove-unused-preferences-fields.patch
 core/ungoogled-chromium/fix-building-without-enabling-reporting.patch
+core/ungoogled-chromium/block-requests.patch
 core/bromite/disable-fetching-field-trials.patch
 
 extra/inox-patchset/0006-modify-default-prefs.patch


### PR DESCRIPTION
This patch prevents connection attempts that aren't addressed by their own patches.  

Fixes #1008, #995, and #1049 