### PR TITLE
Revert "Bugfix for omnibox-autocomplete-filtering related crash"

### DIFF
--- a/patches/extra/ungoogled-chromium/add-flag-for-omnibox-autocomplete-filtering.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-omnibox-autocomplete-filtering.patch
@@ -38,7 +38,7 @@
  #include "base/feature_list.h"
  #include "base/format_macros.h"
  #include "base/metrics/histogram.h"
-@@ -225,11 +226,31 @@
+@@ -225,11 +226,27 @@
        first_query_(true),
        search_service_worker_signal_sent_(false),
        template_url_service_(provider_client_->GetTemplateURLService()) {
@@ -51,10 +51,6 @@
    if (provider_types & AutocompleteProvider::TYPE_BUILTIN)
      providers_.push_back(new BuiltinProvider(provider_client_.get()));
 +  if (flag_value == "search-suggestions-only" || flag_value == "search-suggestions-and-bookmarks") {
-+    if (provider_types & AutocompleteProvider::TYPE_KEYWORD) {
-+      keyword_provider_ = new KeywordProvider(provider_client_.get(), this);
-+      providers_.push_back(keyword_provider_);
-+    }
 +    if (provider_types & AutocompleteProvider::TYPE_SEARCH) {
 +      search_provider_ = new SearchProvider(provider_client_.get(), this);
 +      providers_.push_back(search_provider_);


### PR DESCRIPTION
Reverts Eloston/ungoogled-chromium#1158