### PR TITLE
Bugfix for omnibox-autocomplete-filtering related crash

### DIFF
--- a/patches/extra/ungoogled-chromium/add-flag-for-omnibox-autocomplete-filtering.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-omnibox-autocomplete-filtering.patch
@@ -38,7 +38,7 @@
  #include "base/feature_list.h"
  #include "base/format_macros.h"
  #include "base/metrics/histogram.h"
-@@ -226,11 +227,27 @@ AutocompleteController::AutocompleteCont
+@@ -226,11 +227,31 @@ AutocompleteController::AutocompleteCont
        first_query_(true),
        search_service_worker_signal_sent_(false),
        template_url_service_(provider_client_->GetTemplateURLService()) {
@@ -51,6 +51,10 @@
    if (provider_types & AutocompleteProvider::TYPE_BUILTIN)
      providers_.push_back(new BuiltinProvider(provider_client_.get()));
 +  if (flag_value == "search-suggestions-only" || flag_value == "search-suggestions-and-bookmarks") {
++    if (provider_types & AutocompleteProvider::TYPE_KEYWORD) {
++      keyword_provider_ = new KeywordProvider(provider_client_.get(), this);
++      providers_.push_back(keyword_provider_);
++    }
 +    if (provider_types & AutocompleteProvider::TYPE_SEARCH) {
 +      search_provider_ = new SearchProvider(provider_client_.get(), this);
 +      providers_.push_back(search_provider_);


### PR DESCRIPTION
Re-submission of #1158 adjusted to work with the version 85 update.  
Fixes #1157 