### PR TITLE
Remove unneeded desktop UI

### DIFF
--- a/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
+++ b/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
@@ -1,0 +1,184 @@
+# Removes the Google sign-in sections on the settings page
+--- a/chrome/browser/resources/settings/privacy_page/personalization_options.html
++++ b/chrome/browser/resources/settings/privacy_page/personalization_options.html
+@@ -35,7 +35,7 @@
+         border-top: none;
+       }
+     </style>
+-<if expr="not chromeos">
++<if expr="false">
+     <settings-toggle-button id="signinAllowedToggle"
+         class="hr"
+         disabled="[[syncFirstSetupInProgress_]]"
+@@ -52,6 +52,7 @@
+         label="$i18n{searchSuggestPref}"
+         sub-label="$i18n{searchSuggestPrefDesc}">
+     </settings-toggle-button>
++<if expr="false">
+   <template is="dom-if" if="[[!privacySettingsRedesignEnabled_]]">
+     <settings-toggle-button id="linkDoctor" class="hr"
+         pref="{{prefs.alternate_error_pages.enabled}}"
+@@ -113,6 +114,7 @@
+           on-close="onSignoutDialogClosed_">
+       </settings-signout-dialog>
+     </template>
++</if>
+ 
+ <if expr="not chromeos">
+     <cr-toast id="toast" open="[[showRestartToast_]]">
+# Removes the cloud printing entry on the settings page
+--- a/chrome/browser/resources/settings/printing_page/printing_page.html
++++ b/chrome/browser/resources/settings/printing_page/printing_page.html
+@@ -6,6 +6,7 @@
+         <cr-link-row label="$i18n{localPrintersTitle}"
+             on-click="onTapLocalPrinters_" external></cr-link-row>
+ </if>
++<if expr="false">
+         <cr-link-row class="hr" id="cloudPrinters"
+             label="$i18n{cloudPrintersTitle}" on-click="onTapCloudPrinters_"
+             role-description="$i18n{subpageArrowRoleDescription}">
+@@ -19,4 +20,5 @@
+           </settings-cloud-printers>
+         </settings-subpage>
+       </template>
++</if>
+     </settings-animated-pages>
+# Removes unneeded elements from the profile menu
+--- a/chrome/browser/ui/views/profiles/profile_menu_view.cc
++++ b/chrome/browser/ui/views/profiles/profile_menu_view.cc
+@@ -143,6 +143,7 @@
+ }
+ 
+ gfx::ImageSkia ProfileMenuView::GetSyncIcon() const {
++  return gfx::ImageSkia();
+   Profile* profile = browser()->profile();
+ 
+   if (!profile->IsRegularProfile())
+@@ -414,7 +415,7 @@
+     SetIdentityInfo(
+         profile_attributes->GetAvatarIcon().AsImageSkia(),
+         /*title=*/base::string16(),
+-        l10n_util::GetStringUTF16(IDS_PROFILES_LOCAL_PROFILE_STATE));
++        base::string16());
+   }
+ }
+ 
+@@ -486,6 +487,7 @@
+     return;
+   }
+ 
++  return;
+   // Show sync promos.
+   CoreAccountInfo unconsented_account = identity_manager->GetPrimaryAccountInfo(
+       signin::ConsentLevel::kNotRequired);
+# Removes the link to Google's accessibility site from the settings page
+--- a/chrome/browser/resources/settings/a11y_page/a11y_page.html
++++ b/chrome/browser/resources/settings/a11y_page/a11y_page.html
+@@ -37,10 +37,6 @@
+           </settings-toggle-button>
+         </template>
+ </if>
+-        <cr-link-row class="hr" label="$i18n{moreFeaturesLink}"
+-            on-click="onMoreFeaturesLinkClick_" sub-label="$i18n{a11yWebStore}"
+-            external>
+-        </cr-link-row>
+       </div>
+ <if expr="not is_macosx and not chromeos">
+       <template is="dom-if" route-path="/captions">
+# Removes the option to offer page translations on the settings page
+--- a/chrome/browser/resources/settings/languages_page/languages_page.html
++++ b/chrome/browser/resources/settings/languages_page/languages_page.html
+@@ -208,10 +208,6 @@
+               </a>
+             </div>
+           </div>
+-          <settings-toggle-button id="offerTranslateOtherLanguages"
+-              pref="{{prefs.translate.enabled}}"
+-              label="$i18n{offerToEnableTranslate}">
+-          </settings-toggle-button>
+         </iron-collapse>
+         <settings-toggle-button
+             id="enableSpellcheckingToggle"
+# Removes the option for password leak detection on the settings page
+--- a/chrome/browser/resources/settings/privacy_page/passwords_leak_detection_toggle.html
++++ b/chrome/browser/resources/settings/privacy_page/passwords_leak_detection_toggle.html
+@@ -6,6 +6,7 @@
+           padding-inline-start: 0;
+       }
+     </style>
++<if expr="false">
+     <settings-toggle-button id="passwordsLeakDetectionCheckbox" class="hr"
+         pref="[[passwordsLeakDetectionPref_]]" no-set-pref
+         label="$i18n{passwordsLeakDetectionLabel}"
+@@ -16,3 +17,4 @@
+             prefs.safebrowsing.enhanced.value)]]"
+         on-settings-boolean-control-change="onPasswordsLeakDetectionChange_">
+     </settings-toggle-button>
++</if>
+# Removes the Safety check section on the settings page
+--- a/chrome/browser/resources/settings/basic_page/basic_page.html
++++ b/chrome/browser/resources/settings/basic_page/basic_page.html
+@@ -91,6 +91,7 @@
+             <settings-autofill-page prefs="{{prefs}}"></settings-autofill-page>
+           </settings-section>
+         </template>
++<if expr="false">
+         <template is="dom-if" if="[[showSafetyCheckPage_(
+             pageVisibility.safetyCheck)]]" restamp>
+           <settings-section page-title="$i18n{safetyCheckSectionTitle}"
+@@ -100,6 +101,7 @@
+             </settings-safety-check-page>
+           </settings-section>
+         </template>
++</if>
+         <template is="dom-if" if="[[showPage_(pageVisibility.privacy)]]"
+             restamp>
+           <settings-section page-title="$i18n{privacyPageTitle}"
+# Removes the link to Google's help site on the About page
+--- a/chrome/browser/resources/settings/about_page/about_page.html
++++ b/chrome/browser/resources/settings/about_page/about_page.html
+@@ -124,8 +124,6 @@
+         </div>
+       </template>
+ </if>
+-      <cr-link-row class="hr" id="help" on-click="onHelpTap_"
+-          label="$i18n{aboutGetHelpUsingChrome}" external></cr-link-row>
+ <if expr="_google_chrome">
+       <cr-link-row class="hr" id="reportIssue" on-click="onReportIssueTap_"
+           hidden="[[!prefs.feedback_allowed.value]]"
+# Removes the Safety Check entry on the side menu on the settings page
+--- a/chrome/browser/resources/settings/settings_menu/settings_menu.html
++++ b/chrome/browser/resources/settings/settings_menu/settings_menu.html
+@@ -107,6 +107,7 @@
+         <iron-icon icon="settings:assignment"></iron-icon>
+         $i18n{autofillPageTitle}
+       </a>
++<if expr="false">
+       <template is="dom-if" if="[[privacySettingsRedesignEnabled_]]" restamp>
+         <a href="/safetyCheck" hidden="[[!pageVisibility.safetyCheck]]"
+             id="safetyCheck">
+@@ -114,6 +115,7 @@
+           $i18n{safetyCheckSectionTitle}
+         </a>
+       </template>
++</if>
+       <a href="/privacy" hidden="[[!pageVisibility.privacy]]">
+         <iron-icon icon="cr:security"></iron-icon>
+         $i18n{privacyPageTitle}
+# Removes the 'Tabs from other devices' entry on the History page sidebar
+--- a/chrome/browser/resources/history/side_bar.html
++++ b/chrome/browser/resources/history/side_bar.html
+@@ -101,11 +101,13 @@
+         $i18n{historyMenuItem}
+         <paper-ripple></paper-ripple>
+       </a>
++<if expr="false">
+       <a href="/syncedTabs" class="page-item" path="syncedTabs"
+           on-click="onItemClick_">
+         $i18n{openTabsMenuItem}
+         <paper-ripple></paper-ripple>
+       </a>
++</if>
+       <div class="separator"></div>
+       <a id="clear-browsing-data"
+           href="chrome://settings/clearBrowserData"

--- a/patches/series
+++ b/patches/series
@@ -86,6 +86,7 @@ extra/ungoogled-chromium/enable-default-reduced-referrer-granularity.patch
 extra/ungoogled-chromium/enable-menu-on-reload-button.patch
 extra/ungoogled-chromium/add-flag-for-omnibox-autocomplete-filtering.patch
 extra/ungoogled-chromium/disable-dial-repeating-discovery.patch
+extra/ungoogled-chromium/remove-uneeded-ui.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch


### PR DESCRIPTION
This patch removes UI elements that are no longer needed:

*  Unneeded elements from the profile menu
*  Google sign-in sections on the settings page
*  Cloud printing entry on the settings page
*  Option for password leak detection on the settings page
*  Safety check section on the settings page
*  Safety Check entry on the side menu on the settings page
*  Option to offer page translations on the settings page
*  Link to Google's accessibility site from the settings page
*  Link to Google's help site on the About page
*  'Tabs from other devices' entry on the History page sidebar

Addresses #1131, Fixing #224, #369, and #1130