### PR TITLE
Update ipv6 probing patch to use feature flag

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -21,5 +21,10 @@ If a flag requires a value, you must specify it with an `=` sign; e.g. flag `--f
 * `--omnibox-autocomplete-filtering` - Restrict omnibox autocomplete results to search suggestions (if enabled) or search suggestions and bookmarks. The type of filtering is determined by the values `search-suggestions-only` and `search-suggestions-and-bookmarks`, respectively.
 * `--pdf-plugin-name` - Sets the internal PDF viewer plugin name. Useful for sites that probe JavaScript API `navigator.plugins`. Supports values `chrome` for Chrome, `edge` for Microsoft Edge. Default value when omitted is Chromium.
 * `--scroll-tabs` - Determines if scrolling will cause a switch to a neighboring tab if the cursor hovers over the tabs, or the empty space beside the tabs. The flag requires one the values: `always`, `never`, `incognito-and-guest`. When omitted, the default is to use platform-specific behavior, which is currently enabled only on desktop Linux.
-* `--set-ipv6-probe-false` - (Not in `chrome://flags`) Forces the result of the browser's IPv6 probing (i.e. IPv6 connectivity test) to be unsuccessful. This causes IPv4 addresses to be prioritized over IPv6 addresses. Without this flag, the probing result is set to be successful, which causes IPv6 to be used over IPv4 when possible.
 * `--show-avatar-button` - Sets visibility of the avatar button. The flag requires one of the values: `always`, `incognito-and-guest` (only show Incognito or Guest modes), or `never`.
+
+## Feature flags
+
+Feature flags are enabled with the `--enable-features` switch.  Multiple features can be passed at the same time by separating them with a comma, e.g. `--enable-features=flag1,flag2,flag3`.
+
+* `SetIpv6ProbeFalse` - (Not in `chrome://flags`) Forces the result of the browser's IPv6 probing (i.e. IPv6 connectivity test) to be unsuccessful. This causes IPv4 addresses to be prioritized over IPv6 addresses. Without this flag, the probing result is set to be successful, which causes IPv6 to be used over IPv4 when possible.

--- a/patches/extra/ungoogled-chromium/add-ipv6-probing-option.patch
+++ b/patches/extra/ungoogled-chromium/add-ipv6-probing-option.patch
@@ -1,17 +1,30 @@
 # Disables IPv6 probing and adds an option to change the IPv6 probing result
 # TODO: Consider adding a chrome://flag to set the command-line flag
 
+--- a/net/base/features.cc
++++ b/net/base/features.cc
+@@ -164,5 +164,7 @@
+ const base::Feature kUseLookalikesForNavigationSuggestions{
+     "UseLookalikesForNavigationSuggestions", base::FEATURE_DISABLED_BY_DEFAULT};
+ 
++const base::Feature kSetIpv6ProbeFalse{"SetIpv6ProbeFalse", base::FEATURE_DISABLED_BY_DEFAULT};
++
+ }  // namespace features
+ }  // namespace net
+--- a/net/base/features.h
++++ b/net/base/features.h
+@@ -245,6 +245,8 @@
+ // locally-generated suggestions to visit similar domains.
+ NET_EXPORT extern const base::Feature kUseLookalikesForNavigationSuggestions;
+ 
++NET_EXPORT extern const base::Feature kSetIpv6ProbeFalse;
++
+ }  // namespace features
+ }  // namespace net
+ 
 --- a/net/dns/host_resolver_manager.cc
 +++ b/net/dns/host_resolver_manager.cc
-@@ -30,6 +30,7 @@
- #include "base/bind_helpers.h"
- #include "base/callback.h"
- #include "base/callback_helpers.h"
-+#include "base/command_line.h"
- #include "base/compiler_specific.h"
- #include "base/containers/flat_set.h"
- #include "base/containers/linked_list.h"
-@@ -131,11 +132,6 @@ const unsigned kMinimumTTLSeconds = kCac
+@@ -131,11 +131,6 @@ const unsigned kMinimumTTLSeconds = kCac
  // cached.
  const int kIPv6ProbePeriodMs = 1000;
  
@@ -23,12 +36,12 @@
  enum DnsResolveStatus {
    RESOLVE_STATUS_DNS_SUCCESS = 0,
    RESOLVE_STATUS_PROC_SUCCESS,
-@@ -3584,7 +3580,7 @@ bool HostResolverManager::IsIPv6Reachabl
+@@ -3584,7 +3579,7 @@ bool HostResolverManager::IsIPv6Reachabl
        (tick_clock_->NowTicks() - last_ipv6_probe_time_).InMilliseconds() >
            kIPv6ProbePeriodMs) {
      SetLastIPv6ProbeResult(
 -        IsGloballyReachable(IPAddress(kIPv6ProbeAddress), net_log));
-+        !base::CommandLine::ForCurrentProcess()->HasSwitch("set-ipv6-probe-false"));
++        !base::FeatureList::IsEnabled(features::kSetIpv6ProbeFalse));
      cached = false;
    }
    net_log.AddEvent(


### PR DESCRIPTION
At some point the code this patch affects was moved off the main thread and no longer has access to the commandline switches.  
This caused `HasSwitch("set-ipv6-probe-false")` to always return false.  

Updating the patch to use a feature flag instead solves the issue while keeping the changes minimal.  
To make use of the change, the executable will now need to be passed `--enable-features=SetIpv6ProbeFalse` instead of `--set-ipv6-probe-false`.

Fixes #1172 