### PR TITLE
Add flag to set whether a window should close with the last tab

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -7,6 +7,7 @@ This is an exhaustive list of command-line switches and `chrome://flags` introdu
 If a flag requires a value, you must specify it with an `=` sign; e.g. flag `--foo` with value `bar` should be written as `--foo=bar`.
 
 * `--bookmark-bar-ntp` - Sets the visibility of the bookmark bar on the New Tab Page. Only takes the value `never`.
+* `--close-window-with-last-tab` - Determines whether a window should close once the last tab is closed.  Only takes the value `never`.  Also configurable under `chrome://flags`
 * `--disable-beforeunload` (Not in `chrome://flags`) - Disables JavaScript dialog boxes triggered by `beforeunload`
 * `--disable-encryption` (Windows only, not in `chrome://flags`) - Disable encryption of cookies, passwords, and settings which uses a generated machine-specific encryption key. This is used to enable portable user data directories.
 * `--disable-machine-id` (Windows only, not in `chrome://flags`) - Disables use of a generated machine-specific ID to lock the user data directory to that machine. This is used to enable portable user data directories.

--- a/patches/extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
+++ b/patches/extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
@@ -27,7 +27,7 @@
  #include "ui/accessibility/accessibility_features.h"
  #include "ui/accessibility/accessibility_switches.h"
  #include "ui/base/ui_base_features.h"
-@@ -2042,6 +2043,14 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -2053,6 +2054,14 @@ const FeatureEntry kFeatureEntries[] = {
       "Set internal PDF plugin name",
       "Sets the internal PDF viewer plugin name. Useful for sites that probe JS API navigator.plugins",
       kOsDesktop, MULTI_VALUE_TYPE(kPDFPluginNameChoices)},

--- a/patches/extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch
+++ b/patches/extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch
@@ -23,7 +23,7 @@ approach to change color components.
 
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -2056,6 +2056,10 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -2067,6 +2067,10 @@ const FeatureEntry kFeatureEntries[] = {
       "Enable Canvas::measureText() fingerprint deception",
       "Scale the output values of Canvas::measureText() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization.",
       kOsAll, SINGLE_VALUE_TYPE(switches::kFingerprintingCanvasMeasureTextNoise)},

--- a/patches/extra/bromite/flag-max-connections-per-host.patch
+++ b/patches/extra/bromite/flag-max-connections-per-host.patch
@@ -27,7 +27,7 @@ with limited CPU/memory resources and it is disabled by default.
      "//components/offline_items_collection/core",
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -757,6 +757,11 @@ const FeatureEntry::Choice kForceEffecti
+@@ -764,6 +764,11 @@ const FeatureEntry::Choice kForceEffecti
       net::kEffectiveConnectionType4G},
  };
  
@@ -39,7 +39,7 @@ with limited CPU/memory resources and it is disabled by default.
  // Ensure that all effective connection types returned by Network Quality
  // Estimator (NQE) are also exposed via flags.
  static_assert(net::EFFECTIVE_CONNECTION_TYPE_LAST + 2 ==
-@@ -3057,6 +3062,9 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -3068,6 +3073,9 @@ const FeatureEntry kFeatureEntries[] = {
       flag_descriptions::kAutofillCreditCardUploadDescription, kOsAll,
       FEATURE_VALUE_TYPE(autofill::features::kAutofillUpstream)},
  #endif  // TOOLKIT_VIEWS || OS_ANDROID

--- a/patches/extra/ungoogled-chromium/add-flag-to-close-window-with-last-tab.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-close-window-with-last-tab.patch
@@ -1,0 +1,48 @@
+--- a/chrome/browser/about_flags.cc
++++ b/chrome/browser/about_flags.cc
+@@ -315,6 +315,13 @@
+      "search-suggestions-and-bookmarks"},
+ };
+ 
++const FeatureEntry::Choice kCloseWindowWithLastTab[] = {
++    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
++    {"Never",
++     "close-window-with-last-tab",
++     "never"},
++};
++
+ const FeatureEntry::Choice kTouchEventFeatureDetectionChoices[] = {
+     {flags_ui::kGenericExperimentChoiceDisabled, "", ""},
+     {flags_ui::kGenericExperimentChoiceEnabled,
+@@ -2038,6 +2045,10 @@
+      "Omnibox Autocomplete Filtering",
+      "Restrict omnibox autocomplete results to search suggestions (if enabled) or search suggestions and bookmarks.",
+      kOsAll, MULTI_VALUE_TYPE(kOmniboxAutocompleteFiltering)},
++    {"close-window-with-last-tab",
++     "Close window with last tab",
++     "Determines whether a window should close once the last tab is closed.",
++     kOsDesktop, MULTI_VALUE_TYPE(kCloseWindowWithLastTab)},
+     {"pdf-plugin-name",
+      "Set internal PDF plugin name",
+      "Sets the internal PDF viewer plugin name. Useful for sites that probe JS API navigator.plugins",
+--- a/chrome/browser/ui/tabs/tab_strip_model.cc
++++ b/chrome/browser/ui/tabs/tab_strip_model.cc
+@@ -10,6 +10,7 @@
+ #include <utility>
+ 
+ #include "base/auto_reset.h"
++#include "base/command_line.h"
+ #include "base/containers/flat_map.h"
+ #include "base/macros.h"
+ #include "base/metrics/histogram_macros.h"
+@@ -1680,6 +1681,10 @@
+   if (items.empty())
+     return true;
+ 
++  const std::string flag_value = base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("close-window-with-last-tab");
++  if (flag_value == "never" && !closing_all_ && items.size() == count())
++    delegate()->AddTabAt(GURL(), -1, true);
++
+   const bool closing_all = static_cast<int>(items.size()) == count();
+   base::WeakPtr<TabStripModel> ref = weak_factory_.GetWeakPtr();
+   if (closing_all) {

--- a/patches/series
+++ b/patches/series
@@ -86,6 +86,7 @@ extra/ungoogled-chromium/enable-menu-on-reload-button.patch
 extra/ungoogled-chromium/add-flag-for-omnibox-autocomplete-filtering.patch
 extra/ungoogled-chromium/disable-dial-repeating-discovery.patch
 extra/ungoogled-chromium/remove-uneeded-ui.patch
+extra/ungoogled-chromium/add-flag-to-close-window-with-last-tab.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch


### PR DESCRIPTION
This PR adds a flag that allows the user to set whether a window should close when the last tab is closed.  
Closing the last tab will instead open a new tab when `close-window-with-last-tab` is set to `never`.  The window can still be closed via the menu, the titlebar, keyboard shortcut, etc.  

I was previously using an addon to handle this.  Unfortunately it needed to keep a blank tab pinned to function, polluted the tab history, and it also prevented dragging tabs between windows.  
It made more sense to add a few lines of code to implement the functionality.  