### PR TITLE
Update UI removals for 86.0.4240.111

### DIFF
--- a/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
+++ b/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
@@ -1,17 +1,27 @@
-# Removes the Google sign-in sections on the settings page
+# Removes in order:
+# 'Tabs from other devices' entry on the History page sidebar
+# link to Google's accessibility site from the settings page
+# link to Google's help site on the About page
+# Safety check section on the settings page
+# option to offer page translations on the settings page
+# cloud printing entry on the settings page
+# option for password leak detection on the settings page
+# Google sign-in and Anonymized Data Collection sections
+# Advanced Protection Program link on the security settings page
+# Safety Check entry on the side menu on the settings page
+# unneeded elements from the profile menu
+
 --- a/chrome/browser/resources/history/side_bar.html
 +++ b/chrome/browser/resources/history/side_bar.html
-@@ -101,11 +101,13 @@
+@@ -101,11 +101,6 @@
          $i18n{historyMenuItem}
          <paper-ripple></paper-ripple>
        </a>
-+<if expr="false">
-       <a href="/syncedTabs" class="page-item" path="syncedTabs"
-           on-click="onItemClick_">
-         $i18n{openTabsMenuItem}
-         <paper-ripple></paper-ripple>
-       </a>
-+</if>
+-      <a href="/syncedTabs" class="page-item" path="syncedTabs"
+-          on-click="onItemClick_">
+-        $i18n{openTabsMenuItem}
+-        <paper-ripple></paper-ripple>
+-      </a>
        <div class="separator"></div>
        <a id="clear-browsing-data"
            href="chrome://settings/clearBrowserData"
@@ -116,19 +126,43 @@
      <settings-toggle-button id="signinAllowedToggle"
          class="hr"
          disabled="[[syncFirstSetupInProgress_]]"
+@@ -76,12 +76,6 @@
+     </settings-toggle-button>
+ </if><!-- not chromeos -->
+ </if><!-- _google_chrome -->
+-    <settings-toggle-button
+-        class="hr"
+-        pref="{{prefs.url_keyed_anonymized_data_collection.enabled}}"
+-        label="$i18n{urlKeyedAnonymizedDataCollection}"
+-        sub-label="$i18n{urlKeyedAnonymizedDataCollectionDesc}">
+-    </settings-toggle-button>
+ <if expr="_google_chrome">
+     <settings-toggle-button id="spellCheckControl"
+         class="hr"
+--- a/chrome/browser/resources/settings/privacy_page/security_page.html
++++ b/chrome/browser/resources/settings/privacy_page/security_page.html
+@@ -82,10 +82,3 @@
+         sub-label="$i18n{manageCertificatesDescription}"
+         on-click="onManageCertificatesClick_"></cr-link-row>
+ </if>
+-    <cr-link-row id="advanced-protection-program-link"
+-        class="hr"
+-        label="$i18n{advancedProtectionProgramTitle}"
+-        sub-label="$i18n{advancedProtectionProgramDesc}"
+-        on-click="onAdvancedProtectionProgramLinkClick_"
+-        external>
+-    </cr-link-row>
 --- a/chrome/browser/resources/settings/settings_menu/settings_menu.html
 +++ b/chrome/browser/resources/settings/settings_menu/settings_menu.html
-@@ -107,11 +107,13 @@
+@@ -107,11 +107,6 @@
          <iron-icon icon="settings:assignment"></iron-icon>
          $i18n{autofillPageTitle}
        </a>
-+<if expr="false">
-       <a href="/safetyCheck" hidden="[[!pageVisibility.safetyCheck]]"
-           id="safetyCheck">
-         <iron-icon icon="settings20:safety-check"></iron-icon>
-         $i18n{safetyCheckSectionTitle}
-       </a>
-+</if>
+-      <a href="/safetyCheck" hidden="[[!pageVisibility.safetyCheck]]"
+-          id="safetyCheck">
+-        <iron-icon icon="settings20:safety-check"></iron-icon>
+-        $i18n{safetyCheckSectionTitle}
+-      </a>
        <a href="/privacy" hidden="[[!pageVisibility.privacy]]">
          <iron-icon icon="cr:security"></iron-icon>
          $i18n{privacyPageTitle}


### PR DESCRIPTION
This updates the ui removal patch to also remove the Anonymized Data Collection and Advanced Protection Program sections:

![Screenshot_20201018_191924](https://user-images.githubusercontent.com/40727284/96454827-06d78200-11e2-11eb-8aed-8eead86501c3.png)

![Screenshot_20201018_191939](https://user-images.githubusercontent.com/40727284/96454841-0a6b0900-11e2-11eb-97cd-56b08fe5e9c8.png)

I also moved the comments to the top to keep quilt from eating them.  