### PR TITLE
New version check

### DIFF
--- a/.github/ISSUE_TEMPLATE/create-an--updating-to-chromium-x-x-x-x-.md
+++ b/.github/ISSUE_TEMPLATE/create-an--updating-to-chromium-x-x-x-x-.md
@@ -1,13 +1,16 @@
 ---
 name: Create an "Updating to Chromium x.x.x.x"
 about: For letting the community track progress to a new stable Chromium
-title: Updating to Chromium [VERSION_HERE]
+title: Updating to Chromium {{ env.VERSION }}
 labels: enhancement, help wanted
 assignees: ''
 
 ---
 
-### Please respond if you would like to update ungoogled-chromium to the new stable Chromium version.
+Chromium stable channel has been updated to a newer version. See [the original posting]({{ env.LINK }}) for more information.
+Feel free to ask questions and discuss issues here along the way. Thanks!
+
+### Please respond if you would like to update ungoogled-chromium to the new stable Chromium version
 
 ## Notes for the developer
 
@@ -15,9 +18,7 @@ Once you claim it, it is advisable that you create a [Draft Pull Request](https:
 
 ![GitHub Interface for creating Draft Pull Requests](https://help.github.com/assets/images/help/pull_requests/pullrequest-send.png)
 
-Finally, make sure to reference this issue in your PR.
-
-Feel free to ask questions and discuss issues here along the way. Thanks!
+Finally, make sure to reference this issue in your PR
 
 ## Notes for others
 

--- a/.github/workflows/new_version_check.yml
+++ b/.github/workflows/new_version_check.yml
@@ -1,0 +1,40 @@
+name: New version check
+
+on:
+  # running every 6 hours
+  schedule:
+    - cron: '48 */6 * * *'
+jobs:
+  check:
+    # do not run in forks
+    if: github.repository == 'Eloston/ungoogled-chromium'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read news items
+        id: rss-out
+        # a little bit of Shell-Fu
+        # obtaining latest version and a link to a corresponding news item
+        run: echo "::set-output name=version::$( rdom () { local IFS=\> ; read -d \< E C ; }; while rdom; do if [[ $C = 'Stable Channel Update for Desktop' ]]; then while rdom; do if [[ $C =~ [[:space:]]([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)[[:space:]] ]]; then echo ${BASH_REMATCH[1]}; while rdom; do if [[ $E = 'feedburner:origLink' ]]; then echo "::set-output name=link::$C"; exit; fi done fi done fi done < <(wget -q -O- 'https://chromereleases.googleblog.com/feeds/posts/default') )"
+      - uses: PF4Public/check-if-issue-exists-action@master
+        name: Check if Issue Exists
+        id: check_if_issue_exists
+        with:
+          repo: Eloston/ungoogled-chromium
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: Updating to Chromium ${{ steps.rss-out.outputs.version }}
+          labels: enhancement, help wanted
+      - uses: actions/checkout@v2
+        # we need this to use create-an--updating-to-chromium-x-x-x-x-.md
+        # skip it if there's nothing new
+        if: steps.check_if_issue_exists.outputs.exists == 'false'
+      - name: Create Issue
+        # skip it if there's nothing new
+        if: steps.check_if_issue_exists.outputs.exists == 'false'
+        uses: JasonEtco/create-an-issue@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # variables from Shell-Fu step
+          VERSION: ${{ steps.rss-out.outputs.version }}
+          LINK: ${{ steps.rss-out.outputs.link }}
+        with:
+          filename:  .github/ISSUE_TEMPLATE/create-an--updating-to-chromium-x-x-x-x-.md


### PR DESCRIPTION
This PR adds a GutHub workflow, which checks for a new Chromium version and creates an "Updating to …" issue.

I allowed it to run [for a while](https://github.com/PF4Public/ungoogled-chromium/actions) in [my fork](https://github.com/PF4Public/ungoogled-chromium/issues?q=is%3Aissue+), while improving it.

Addressed concerns are:
* Running every 6 hours, not a heavy one
* Does not by default run in forks and [it is indeed so](https://github.com/PF4Public/ungoogled-chromium/actions), now that I have changed `if: github.repository ==` condition
* `check-if-issue-exists-action` didn't originally consider closed issues, which is a show-stopper for this use-case. I have however fixed that and [created a PR](https://github.com/nickderobertis/check-if-issue-exists-action/pull/1), which is unfortunately not yet accepted, hence `PF4Public/check-if-issue-exists-action@master`.
* It skips as much as possible if nothing changed/nothing to do
* To avoid the [confusion](https://github.com/Eloston/ungoogled-chromium/pull/1210#issuecomment-709610422), when a new issue was created by this workflow in my fork, which I took for granted for all platforms, but stable was only bumped on Mac, it also provides a link to the original news item

I believe it is now ready to be merged

PS: after merging it should (within 6 hours) create [Updating to Chromium 86.0.4240.111](https://github.com/PF4Public/ungoogled-chromium/issues/15)