### PR TITLE
Exclude prebuilt object for Windows arm64 builds

### DIFF
--- a/devutils/update_lists.py
+++ b/devutils/update_lists.py
@@ -55,6 +55,8 @@ PRUNING_EXCLUDE_PATTERNS = [
     'components/language/content/browser/ulp_language_code_locator/geolanguage-data_rank0.bin',
     'components/language/content/browser/ulp_language_code_locator/geolanguage-data_rank1.bin',
     'components/language/content/browser/ulp_language_code_locator/geolanguage-data_rank2.bin',
+    # Exclusion for required prebuilt object for Windows arm64 builds
+    'third_party/crashpad/crashpad/util/misc/capture_context_win_arm64.obj',
     'third_party/icu/common/icudtl.dat', # Exclusion for ICU data
     # Exclusions for safe file extensions
     '*.ttf',

--- a/pruning.list
+++ b/pruning.list
@@ -9727,7 +9727,6 @@ third_party/closure_compiler/compiler/compiler.jar
 third_party/crashpad/crashpad/handler/win/z7_test.dll
 third_party/crashpad/crashpad/snapshot/elf/elf_image_reader_fuzzer_corpus/crashpad_snapshot_test_both_dt_hash_styles.so
 third_party/crashpad/crashpad/snapshot/elf/elf_image_reader_fuzzer_corpus/ret42
-third_party/crashpad/crashpad/util/misc/capture_context_win_arm64.obj
 third_party/crashpad/crashpad/util/net/testdata/binary_http_body.dat
 third_party/depot_tools/ninja-linux32
 third_party/depot_tools/ninja-linux64


### PR DESCRIPTION
*(Please ensure you have read SUPPORT.md and docs/contributing.md before submitting the Pull Request)*

There is no way to regenerate this object, and the object itself is required to compile arm64 builds of ungoogled-chromium for Microsoft Windows.