### PR TITLE
Flag overhaul

### DIFF
--- a/devutils/validate_patches.py
+++ b/devutils/validate_patches.py
@@ -525,7 +525,7 @@ def _apply_file_unidiff(patched_file, files_under_test):
         assert len(patched_file) == 1 # Should be only one hunk
         assert patched_file[0].removed == 0
         assert patched_file[0].target_start == 1
-        files_under_test[patched_file_path] = [x.value for x in patched_file[0]]
+        files_under_test[patched_file_path] = [x.value.rstrip('\n') for x in patched_file[0]]
     elif patched_file.is_removed_file:
         # Remove lines to see if file to be removed matches patch
         _modify_file_lines(patched_file, files_under_test[patched_file_path])

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -1,31 +1,52 @@
 # List of flags and switches
 
-This is an exhaustive list of command-line switches and `chrome://flags` introduced by ungoogled-chromium
+This is an exhaustive list of command-line switches and flags introduced by ungoogled-chromium.  
+Each switch has a corresponding entry on the `chrome://flags` page which can be filtered by searching for `ungoogled-chromium`.  
 
-**NOTE**: If you add a command-line argument that is also in `chrome://flags`, the flag's state will not be indicated in `chrome://flags`. There is no universal way to ensure command-line flags are taking effect, but you can find if they're being seen by checking `chrome://version`.
+If a switch requires a value, you must specify it with an `=` sign; e.g. flag `--foo` with value `bar` should be written as `--foo=bar`.
 
-If a flag requires a value, you must specify it with an `=` sign; e.g. flag `--foo` with value `bar` should be written as `--foo=bar`.
+> **NOTE**: If you add a command-line argument that is also in `chrome://flags`, the flag's state will not be indicated in `chrome://flags`. There is no universal way to ensure command-line flags are taking effect, but you can find if they're being seen by checking `chrome://version`.
 
-* `--bookmark-bar-ntp` - Sets the visibility of the bookmark bar on the New Tab Page. Only takes the value `never`.
-* `--close-window-with-last-tab` - Determines whether a window should close once the last tab is closed.  Only takes the value `never`.  Also configurable under `chrome://flags`
-* `--disable-beforeunload` (Not in `chrome://flags`) - Disables JavaScript dialog boxes triggered by `beforeunload`
-* `--disable-encryption` (Windows only, not in `chrome://flags`) - Disable encryption of cookies, passwords, and settings which uses a generated machine-specific encryption key. This is used to enable portable user data directories.
-* `--disable-machine-id` (Windows only, not in `chrome://flags`) - Disables use of a generated machine-specific ID to lock the user data directory to that machine. This is used to enable portable user data directories.
-* `--disable-search-engine-collection` - Disable automatic search engine scraping from webpages.
-* `--enable-stacked-tab-strip` and `--enable-tab-adjust-layout` - These flags adjust the tab strip behavior. `--enable-stacked-tab-strip` is also configurable in `chrome://flags` Please note that they are not well tested, so proceed with caution.
-* `--extension-mime-request-handling` - Change how extension MIME types (CRX and user scripts) are handled. Acceptable values are `download-as-regular-file` or `always-prompt-for-install`. Leave unset to use normal behavior. It is also configurable under `chrome://flags`
-* `--fingerprinting-canvas-image-data-noise` (Added flag to Bromite feature) - Implements fingerprinting deception for Canvas image data retrieved via JS APIs. In the data, at most 10 pixels are slightly modified.
-* `--fingerprinting-canvas-measuretext-noise` (Added flag to Bromite feature) - Scale the output values of Canvas::measureText() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization.
-* `--fingerprinting-client-rects-noise` (Added flag to Bromite feature) - Implements fingerprinting deception of JS APIs `getClientRects()` and `getBoundingClientRect()` by scaling their output values with a random factor in the range -0.0003% to 0.0003%, which are recomputed for every document instantiation.
-* `--hide-crashed-bubble` (Not in `chrome://flags`) - Hides the bubble box with the message "Restore Pages? Chromium didn't shut down correctly." that shows on startup after the browser did not exit cleanly.
-* `--max-connections-per-host` (from Bromite) - Configure the maximum allowed connections per host. Valid values are `6` and `15`
-* `--omnibox-autocomplete-filtering` - Restrict omnibox autocomplete results to search suggestions (if enabled) or search suggestions and bookmarks. The type of filtering is determined by the values `search-suggestions-only` and `search-suggestions-and-bookmarks`, respectively.
-* `--pdf-plugin-name` - Sets the internal PDF viewer plugin name. Useful for sites that probe JavaScript API `navigator.plugins`. Supports values `chrome` for Chrome, `edge` for Microsoft Edge. Default value when omitted is Chromium.
-* `--scroll-tabs` - Determines if scrolling will cause a switch to a neighboring tab if the cursor hovers over the tabs, or the empty space beside the tabs. The flag requires one the values: `always`, `never`, `incognito-and-guest`. When omitted, the default is to use platform-specific behavior, which is currently enabled only on desktop Linux.
-* `--show-avatar-button` - Sets visibility of the avatar button. The flag requires one of the values: `always`, `incognito-and-guest` (only show Incognito or Guest modes), or `never`.
+- ### Available on all platforms
+
+  <code>Switch&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code> | Description
+  -- | --
+  `--disable-beforeunload` | Disables JavaScript dialog boxes triggered by `beforeunload`
+  `--disable-search-engine-collection` | Disable automatic search engine scraping from webpages.
+  `--enable-stacked-tab-strip`<br>`--enable-tab-adjust-layout` | These flags adjust the tab strip behavior. Please note that they are not well tested, so proceed with caution.
+  `--extension-mime-request-handling` | Change how extension MIME types (CRX and user scripts) are handled. Acceptable values are `download-as-regular-file` or `always-prompt-for-install`. Leave unset to use normal behavior.
+  `--fingerprinting-canvas-image-data-noise` | (Added flag to Bromite feature) Implements fingerprinting deception for Canvas image data retrieved via JS APIs. In the data, at most 10 pixels are slightly modified.
+  `--fingerprinting-canvas-measuretext-noise` | (Added flag to Bromite feature) Scale the output values of Canvas::measureText() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization.
+  `--fingerprinting-client-rects-noise` | (Added flag to Bromite feature) Implements fingerprinting deception of JS APIs `getClientRects()` and `getBoundingClientRect()` by scaling their output values with a random factor in the range -0.0003% to 0.0003%, which are recomputed for every document instantiation.
+  `--hide-crashed-bubble` | Hides the bubble box with the message "Restore Pages? Chromium didn't shut down correctly." that shows on startup after the browser did not exit cleanly.
+  `--max-connections-per-host` | (from Bromite) Configure the maximum allowed connections per host. Valid values are `6` and `15`
+  `--omnibox-autocomplete-filtering` | Restrict omnibox autocomplete results to search suggestions (if enabled) or search suggestions and bookmarks. The type of filtering is determined by the values `search-suggestions-only` and `search-suggestions-and-bookmarks`, respectively.
+
+- ### Available only on desktop
+
+  <code>Switch&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code> | Description
+  -- | --
+  `--bookmark-bar-ntp` | Sets the visibility of the bookmark bar on the New Tab Page. Only takes the value `never`.
+  `--close-window-with-last-tab` | Determines whether a window should close once the last tab is closed.  Only takes the value `never`.
+  `--pdf-plugin-name` | Sets the internal PDF viewer plugin name. Useful for sites that probe JavaScript API `navigator.plugins`. Supports values `chrome` for Chrome, `edge` for Microsoft Edge. Default value when omitted is Chromium.
+  `--scroll-tabs` | Determines if scrolling will cause a switch to a neighboring tab if the cursor hovers over the tabs, or the empty space beside the tabs. The flag requires one the values: `always`, `never`, `incognito-and-guest`. When omitted, the default is to use platform-specific behavior, which is currently enabled only on desktop Linux.
+  `--show-avatar-button` | Sets visibility of the avatar button. The flag requires one of the values: `always`, `incognito-and-guest` (only show Incognito or Guest modes), or `never`.
+
+  - #### Available only on Windows
+
+    <code>Switch&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code> | Description
+    -- | --
+    `--disable-encryption` | Disable encryption of cookies, passwords, and settings which uses a generated machine-specific encryption key. This is used to enable portable user data directories.
+    `--disable-machine-id` | Disables use of a generated machine-specific ID to lock the user data directory to that machine. This is used to enable portable user data directories.
+
 
 ## Feature flags
 
-Feature flags are enabled with the `--enable-features` switch.  Multiple features can be passed at the same time by separating them with a comma, e.g. `--enable-features=flag1,flag2,flag3`.
+Feature flags are similar to switches with the difference being that they are passed as values for the `--enable-features` switch.  Multiple features can be passed at the same time by separating them with a comma, e.g. `--enable-features=flag1,flag2,flag3`.  
+These are also available on the `chrome://flags` page.  
 
-* `SetIpv6ProbeFalse` - (Not in `chrome://flags`) Forces the result of the browser's IPv6 probing (i.e. IPv6 connectivity test) to be unsuccessful. This causes IPv4 addresses to be prioritized over IPv6 addresses. Without this flag, the probing result is set to be successful, which causes IPv6 to be used over IPv4 when possible.
+- ### Available on all platforms
+
+  <code>Feature&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code> | Description
+  -- | --
+  `SetIpv6ProbeFalse` | Forces the result of the browser's IPv6 probing (i.e. IPv6 connectivity test) to be unsuccessful. This causes IPv4 addresses to be prioritized over IPv6 addresses. Without this flag, the probing result is set to be successful, which causes IPv6 to be used over IPv4 when possible.

--- a/patches/extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
+++ b/patches/extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
@@ -27,21 +27,21 @@
  #include "ui/accessibility/accessibility_features.h"
  #include "ui/accessibility/accessibility_switches.h"
  #include "ui/base/ui_base_features.h"
-@@ -2544,6 +2545,14 @@ const FeatureEntry kFeatureEntries[] = {
-      "Set internal PDF plugin name",
-      "Sets the internal PDF viewer plugin name. Useful for sites that probe JS API navigator.plugins",
-      kOsDesktop, MULTI_VALUE_TYPE(kPDFPluginNameChoices)},
+--- a/chrome/browser/bromite_flag_entries.h
++++ b/chrome/browser/bromite_flag_entries.h
+@@ -4,4 +4,12 @@
+ 
+ #ifndef CHROME_BROWSER_BROMITE_FLAG_ENTRIES_H_
+ #define CHROME_BROWSER_BROMITE_FLAG_ENTRIES_H_
 +    {"fingerprinting-client-rects-noise",
 +     "Enable get*ClientRects() fingerprint deception",
-+     "Scale the output values of Range::getClientRects() and Element::getBoundingClientRect() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization.",
++     "Scale the output values of Range::getClientRects() and Element::getBoundingClientRect() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization.  ungoogled-chromium flag, Bromite feature.",
 +     kOsAll, SINGLE_VALUE_TYPE(switches::kFingerprintingClientRectsNoise)},
 +    {"fingerprinting-canvas-measuretext-noise",
 +     "Enable Canvas::measureText() fingerprint deception",
-+     "Scale the output values of Canvas::measureText() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization.",
++     "Scale the output values of Canvas::measureText() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization.  ungoogled-chromium flag, Bromite feature.",
 +     kOsAll, SINGLE_VALUE_TYPE(switches::kFingerprintingCanvasMeasureTextNoise)},
-     {"ignore-gpu-blocklist", flag_descriptions::kIgnoreGpuBlocklistName,
-      flag_descriptions::kIgnoreGpuBlocklistDescription, kOsAll,
-      SINGLE_VALUE_TYPE(switches::kIgnoreGpuBlocklist)},
+ #endif  // CHROME_BROWSER_BROMITE_FLAG_ENTRIES_H_
 --- a/content/browser/BUILD.gn
 +++ b/content/browser/BUILD.gn
 @@ -226,6 +226,7 @@ source_set("browser") {

--- a/patches/extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch
+++ b/patches/extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch
@@ -21,19 +21,17 @@ approach to change color components.
  .../platform/graphics/static_bitmap_image.h        |   2 +
  4 files changed, 163 insertions(+), 2 deletions(-)
 
---- a/chrome/browser/about_flags.cc
-+++ b/chrome/browser/about_flags.cc
-@@ -2558,6 +2558,10 @@ const FeatureEntry kFeatureEntries[] = {
-      "Enable Canvas::measureText() fingerprint deception",
-      "Scale the output values of Canvas::measureText() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization.",
-      kOsAll, SINGLE_VALUE_TYPE(switches::kFingerprintingCanvasMeasureTextNoise)},
+--- a/chrome/browser/bromite_flag_entries.h
++++ b/chrome/browser/bromite_flag_entries.h
+@@ -16,4 +16,8 @@
+      flag_descriptions::kMaxConnectionsPerHostName,
+      flag_descriptions::kMaxConnectionsPerHostDescription,
+      kOsAll, MULTI_VALUE_TYPE(kMaxConnectionsPerHostChoices)},
 +    {"fingerprinting-canvas-image-data-noise",
 +     "Enable Canvas image data fingerprint deception",
-+     "Slightly modifies at most 10 pixels in Canvas image data extracted via JS APIs",
++     "Slightly modifies at most 10 pixels in Canvas image data extracted via JS APIs.  ungoogled-chromium flag, Bromite feature.",
 +     kOsAll, SINGLE_VALUE_TYPE(switches::kFingerprintingCanvasImageDataNoise)},
-     {"ignore-gpu-blocklist", flag_descriptions::kIgnoreGpuBlocklistName,
-      flag_descriptions::kIgnoreGpuBlocklistDescription, kOsAll,
-      SINGLE_VALUE_TYPE(switches::kIgnoreGpuBlocklist)},
+ #endif  // CHROME_BROWSER_BROMITE_FLAG_ENTRIES_H_
 --- a/content/browser/renderer_host/render_process_host_impl.cc
 +++ b/content/browser/renderer_host/render_process_host_impl.cc
 @@ -3379,6 +3379,7 @@ void RenderProcessHostImpl::PropagateBro

--- a/patches/extra/bromite/flag-max-connections-per-host.patch
+++ b/patches/extra/bromite/flag-max-connections-per-host.patch
@@ -25,30 +25,28 @@ with limited CPU/memory resources and it is disabled by default.
      "//components/network_time",
      "//components/ntp_tiles",
      "//components/offline_items_collection/core",
---- a/chrome/browser/about_flags.cc
-+++ b/chrome/browser/about_flags.cc
-@@ -842,6 +842,11 @@ const FeatureEntry::Choice kForceEffecti
-      net::kEffectiveConnectionType4G},
- };
+--- a/chrome/browser/bromite_flag_choices.h
++++ b/chrome/browser/bromite_flag_choices.h
+@@ -4,4 +4,8 @@
  
+ #ifndef CHROME_BROWSER_BROMITE_FLAG_CHOICES_H_
+ #define CHROME_BROWSER_BROMITE_FLAG_CHOICES_H_
 +const FeatureEntry::Choice kMaxConnectionsPerHostChoices[] = {
 +    {features::kMaxConnectionsPerHostChoiceDefault, "", ""},
 +    {features::kMaxConnectionsPerHostChoice15, switches::kMaxConnectionsPerHost, "15"},
 +};
-+
- // Ensure that all effective connection types returned by Network Quality
- // Estimator (NQE) are also exposed via flags.
- static_assert(net::EFFECTIVE_CONNECTION_TYPE_LAST + 2 ==
-@@ -3586,6 +3591,9 @@ const FeatureEntry kFeatureEntries[] = {
-      flag_descriptions::kAutofillCreditCardUploadDescription, kOsAll,
-      FEATURE_VALUE_TYPE(autofill::features::kAutofillUpstream)},
- #endif  // TOOLKIT_VIEWS || OS_ANDROID
-+    {"max-connections-per-host", flag_descriptions::kMaxConnectionsPerHostName,
-+     flag_descriptions::kMaxConnectionsPerHostDescription, kOsAll,
-+     MULTI_VALUE_TYPE(kMaxConnectionsPerHostChoices)},
-     {"force-ui-direction", flag_descriptions::kForceUiDirectionName,
-      flag_descriptions::kForceUiDirectionDescription, kOsAll,
-      MULTI_VALUE_TYPE(kForceUIDirectionChoices)},
+ #endif  // CHROME_BROWSER_BROMITE_FLAG_CHOICES_H_
+--- a/chrome/browser/bromite_flag_entries.h
++++ b/chrome/browser/bromite_flag_entries.h
+@@ -12,4 +12,8 @@
+      "Enable Canvas::measureText() fingerprint deception",
+      "Scale the output values of Canvas::measureText() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization.  ungoogled-chromium flag, Bromite feature.",
+      kOsAll, SINGLE_VALUE_TYPE(switches::kFingerprintingCanvasMeasureTextNoise)},
++    {"max-connections-per-host",
++     flag_descriptions::kMaxConnectionsPerHostName,
++     flag_descriptions::kMaxConnectionsPerHostDescription,
++     kOsAll, MULTI_VALUE_TYPE(kMaxConnectionsPerHostChoices)},
+ #endif  // CHROME_BROWSER_BROMITE_FLAG_ENTRIES_H_
 --- a/chrome/browser/browser_process_impl.cc
 +++ b/chrome/browser/browser_process_impl.cc
 @@ -18,12 +18,14 @@
@@ -109,7 +107,7 @@ with limited CPU/memory resources and it is disabled by default.
  
 +const char kMaxConnectionsPerHostName[] = "Maximum connections per host";
 +const char kMaxConnectionsPerHostDescription[] =
-+     "Customize maximum allowed connections per host.";
++     "Customize maximum allowed connections per host.  ungoogled-chromium flag, Bromite feature.";
 +
  const char kMediaRouterCastAllowAllIPsName[] =
      "Connect to Cast devices on all IP addresses";

--- a/patches/extra/ungoogled-chromium/add-flag-for-bookmark-bar-ntp.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-bookmark-bar-ntp.patch
@@ -1,30 +1,3 @@
---- a/chrome/browser/about_flags.cc
-+++ b/chrome/browser/about_flags.cc
-@@ -301,6 +301,13 @@ const FeatureEntry::Choice kPDFPluginNam
-     {"Microsoft Edge", switches::kPDFPluginName, "edge"},
- };
- 
-+const FeatureEntry::Choice kBookmarkBarNewTab[] = {
-+    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
-+    {"Never",
-+     "bookmark-bar-ntp",
-+     "never"},
-+};
-+
- #if defined(USE_AURA)
- const FeatureEntry::Choice kPullToRefreshChoices[] = {
-     {flags_ui::kGenericExperimentChoiceDefault, "", ""},
-@@ -2774,6 +2781,10 @@ const FeatureEntry kFeatureEntries[] = {
-     {"focus-mode", flag_descriptions::kFocusMode,
-      flag_descriptions::kFocusModeDescription, kOsDesktop,
-      FEATURE_VALUE_TYPE(features::kFocusMode)},
-+    {"bookmark-bar-ntp",
-+     "Bookmark Bar on New-Tab-Page",
-+     "Disable the Bookmark Bar on the New-Tab-Page", kOsDesktop,
-+     MULTI_VALUE_TYPE(kBookmarkBarNewTab)},
- #if defined(OS_CHROMEOS)
-     {"disable-explicit-dma-fences",
-      flag_descriptions::kDisableExplicitDmaFencesName,
 --- a/chrome/browser/ui/bookmarks/bookmark_tab_helper.cc
 +++ b/chrome/browser/ui/bookmarks/bookmark_tab_helper.cc
 @@ -4,6 +4,7 @@
@@ -49,3 +22,27 @@
  }
  
  void BookmarkTabHelper::AddObserver(BookmarkTabHelperObserver* observer) {
+--- a/chrome/browser/ungoogled_flag_choices.h
++++ b/chrome/browser/ungoogled_flag_choices.h
+@@ -39,4 +39,10 @@ const FeatureEntry::Choice kPDFPluginNam
+     {"Google Chrome", switches::kPDFPluginName, "chrome"},
+     {"Microsoft Edge", switches::kPDFPluginName, "edge"},
+ };
++const FeatureEntry::Choice kBookmarkBarNewTab[] = {
++    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
++    {"Never",
++     "bookmark-bar-ntp",
++     "never"},
++};
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_CHOICES_H_
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -44,4 +44,8 @@
+      "Set internal PDF plugin name",
+      "Sets the internal PDF viewer plugin name. Useful for sites that probe JS API navigator.plugins.  ungoogled-chromium flag.",
+      kOsDesktop, MULTI_VALUE_TYPE(kPDFPluginNameChoices)},
++    {"bookmark-bar-ntp",
++     "Bookmark Bar on New-Tab-Page",
++     "Disable the Bookmark Bar on the New-Tab-Page.  ungoogled-chromium flag.",
++     kOsDesktop, MULTI_VALUE_TYPE(kBookmarkBarNewTab)},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-for-omnibox-autocomplete-filtering.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-omnibox-autocomplete-filtering.patch
@@ -1,9 +1,9 @@
---- a/chrome/browser/about_flags.cc
-+++ b/chrome/browser/about_flags.cc
-@@ -308,6 +308,16 @@ const FeatureEntry::Choice kBookmarkBarN
+--- a/chrome/browser/ungoogled_flag_choices.h
++++ b/chrome/browser/ungoogled_flag_choices.h
+@@ -45,4 +45,13 @@ const FeatureEntry::Choice kBookmarkBarN
+      "bookmark-bar-ntp",
       "never"},
  };
- 
 +const FeatureEntry::Choice kOmniboxAutocompleteFiltering[] = {
 +    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
 +    {"Search suggestions only",
@@ -13,21 +13,18 @@
 +     "omnibox-autocomplete-filtering",
 +     "search-suggestions-and-bookmarks"},
 +};
-+
- #if defined(USE_AURA)
- const FeatureEntry::Choice kPullToRefreshChoices[] = {
-     {flags_ui::kGenericExperimentChoiceDefault, "", ""},
-@@ -2515,6 +2525,10 @@ const FeatureEntry kFeatureEntries[] = {
-      "Force punycode hostnames",
-      "Force punycode in hostnames instead of Unicode when displaying Internationalized Domain Names (IDNs).",
-      kOsAll, SINGLE_VALUE_TYPE("force-punycode-hostnames")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_CHOICES_H_
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -48,4 +48,8 @@
+      "Bookmark Bar on New-Tab-Page",
+      "Disable the Bookmark Bar on the New-Tab-Page.  ungoogled-chromium flag.",
+      kOsDesktop, MULTI_VALUE_TYPE(kBookmarkBarNewTab)},
 +    {"omnibox-autocomplete-filtering",
 +     "Omnibox Autocomplete Filtering",
-+     "Restrict omnibox autocomplete results to search suggestions (if enabled) or search suggestions and bookmarks.",
++     "Restrict omnibox autocomplete results to search suggestions (if enabled) or search suggestions and bookmarks.  ungoogled-chromium flag.",
 +     kOsAll, MULTI_VALUE_TYPE(kOmniboxAutocompleteFiltering)},
-     {"pdf-plugin-name",
-      "Set internal PDF plugin name",
-      "Sets the internal PDF viewer plugin name. Useful for sites that probe JS API navigator.plugins",
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/components/omnibox/browser/autocomplete_controller.cc
 +++ b/components/omnibox/browser/autocomplete_controller.cc
 @@ -15,6 +15,7 @@

--- a/patches/extra/ungoogled-chromium/add-flag-for-pdf-plugin-name.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-pdf-plugin-name.patch
@@ -1,29 +1,3 @@
---- a/chrome/browser/about_flags.cc
-+++ b/chrome/browser/about_flags.cc
-@@ -295,6 +295,12 @@ const FeatureEntry::Choice kScrollEventC
-      "never"}
- };
- 
-+const FeatureEntry::Choice kPDFPluginNameChoices[] = {
-+    {"Chromium", "", ""},
-+    {"Google Chrome", switches::kPDFPluginName, "chrome"},
-+    {"Microsoft Edge", switches::kPDFPluginName, "edge"},
-+};
-+
- #if defined(USE_AURA)
- const FeatureEntry::Choice kPullToRefreshChoices[] = {
-     {flags_ui::kGenericExperimentChoiceDefault, "", ""},
-@@ -2502,6 +2508,10 @@ const FeatureEntry kFeatureEntries[] = {
-      "Force punycode hostnames",
-      "Force punycode in hostnames instead of Unicode when displaying Internationalized Domain Names (IDNs).",
-      kOsAll, SINGLE_VALUE_TYPE("force-punycode-hostnames")},
-+    {"pdf-plugin-name",
-+     "Set internal PDF plugin name",
-+     "Sets the internal PDF viewer plugin name. Useful for sites that probe JS API navigator.plugins",
-+     kOsDesktop, MULTI_VALUE_TYPE(kPDFPluginNameChoices)},
-     {"ignore-gpu-blocklist", flag_descriptions::kIgnoreGpuBlocklistName,
-      flag_descriptions::kIgnoreGpuBlocklistDescription, kOsAll,
-      SINGLE_VALUE_TYPE(switches::kIgnoreGpuBlocklist)},
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
 @@ -5742,7 +5742,7 @@ bool ChromeContentBrowserClient::ShouldA
@@ -281,6 +255,29 @@
    "chromium-pdf-plugin": {
      "mime_types": [
      ],
+--- a/chrome/browser/ungoogled_flag_choices.h
++++ b/chrome/browser/ungoogled_flag_choices.h
+@@ -34,4 +34,9 @@ const FeatureEntry::Choice kScrollEventC
+      "scroll-tabs",
+      "never"}
+ };
++const FeatureEntry::Choice kPDFPluginNameChoices[] = {
++    {"Chromium", "", ""},
++    {"Google Chrome", switches::kPDFPluginName, "chrome"},
++    {"Microsoft Edge", switches::kPDFPluginName, "edge"},
++};
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_CHOICES_H_
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -40,4 +40,8 @@
+      "Scroll switches tab",
+      "Switch to the left/right tab if the wheel-scroll happens over the tabstrip, or the empty space beside the tabstrip.  ungoogled-chromium flag.",
+      kOsDesktop, MULTI_VALUE_TYPE(kScrollEventChangesTab)},
++    {"pdf-plugin-name",
++     "Set internal PDF plugin name",
++     "Sets the internal PDF viewer plugin name. Useful for sites that probe JS API navigator.plugins.  ungoogled-chromium flag.",
++     kOsDesktop, MULTI_VALUE_TYPE(kPDFPluginNameChoices)},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/chrome/common/BUILD.gn
 +++ b/chrome/common/BUILD.gn
 @@ -244,6 +244,7 @@ static_library("common") {

--- a/patches/extra/ungoogled-chromium/add-flag-for-search-engine-collection.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-search-engine-collection.patch
@@ -1,18 +1,16 @@
 # Add flag to disable automatic search engine collection
 
---- a/chrome/browser/about_flags.cc
-+++ b/chrome/browser/about_flags.cc
-@@ -2471,6 +2471,10 @@ const FeatureEntry kFeatureEntries[] = {
-      "Enable stacking in the tab strip",
-      "Forces tabs to be stacked in the tab strip. Otherwise, they follow default behavior.",
-      kOsAll, SINGLE_VALUE_TYPE("enable-stacked-tab-strip")},
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -16,4 +16,8 @@
+      "Handling of extension MIME type requests",
+      "Used when deciding how to handle a request for a CRX or User Script MIME type.  ungoogled-chromium flag.",
+      kOsAll, MULTI_VALUE_TYPE(kExtensionHandlingChoices)},
 +    {"disable-search-engine-collection",
 +     "Disable search engine collection",
-+     "Prevents search engines from being added automatically.",
++     "Prevents search engines from being added automatically.  ungoogled-chromium flag.",
 +     kOsAll, SINGLE_VALUE_TYPE("disable-search-engine-collection")},
-     {"ignore-gpu-blocklist", flag_descriptions::kIgnoreGpuBlocklistName,
-      flag_descriptions::kIgnoreGpuBlocklistDescription, kOsAll,
-      SINGLE_VALUE_TYPE(switches::kIgnoreGpuBlocklist)},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/chrome/renderer/chrome_render_frame_observer.cc
 +++ b/chrome/renderer/chrome_render_frame_observer.cc
 @@ -131,9 +131,10 @@ ChromeRenderFrameObserver::ChromeRenderF

--- a/patches/extra/ungoogled-chromium/add-flag-to-close-window-with-last-tab.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-close-window-with-last-tab.patch
@@ -1,30 +1,3 @@
---- a/chrome/browser/about_flags.cc
-+++ b/chrome/browser/about_flags.cc
-@@ -318,6 +318,13 @@ const FeatureEntry::Choice kOmniboxAutoc
-      "search-suggestions-and-bookmarks"},
- };
- 
-+const FeatureEntry::Choice kCloseWindowWithLastTab[] = {
-+    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
-+    {"Never",
-+     "close-window-with-last-tab",
-+     "never"},
-+};
-+
- #if defined(USE_AURA)
- const FeatureEntry::Choice kPullToRefreshChoices[] = {
-     {flags_ui::kGenericExperimentChoiceDefault, "", ""},
-@@ -2529,6 +2536,10 @@ const FeatureEntry kFeatureEntries[] = {
-      "Omnibox Autocomplete Filtering",
-      "Restrict omnibox autocomplete results to search suggestions (if enabled) or search suggestions and bookmarks.",
-      kOsAll, MULTI_VALUE_TYPE(kOmniboxAutocompleteFiltering)},
-+    {"close-window-with-last-tab",
-+     "Close window with last tab",
-+     "Determines whether a window should close once the last tab is closed.",
-+     kOsDesktop, MULTI_VALUE_TYPE(kCloseWindowWithLastTab)},
-     {"pdf-plugin-name",
-      "Set internal PDF plugin name",
-      "Sets the internal PDF viewer plugin name. Useful for sites that probe JS API navigator.plugins",
 --- a/chrome/browser/ui/tabs/tab_strip_model.cc
 +++ b/chrome/browser/ui/tabs/tab_strip_model.cc
 @@ -10,6 +10,7 @@
@@ -46,3 +19,27 @@
    const bool closing_all = static_cast<int>(items.size()) == count();
    base::WeakPtr<TabStripModel> ref = weak_factory_.GetWeakPtr();
    if (closing_all) {
+--- a/chrome/browser/ungoogled_flag_choices.h
++++ b/chrome/browser/ungoogled_flag_choices.h
+@@ -54,4 +54,10 @@ const FeatureEntry::Choice kOmniboxAutoc
+      "omnibox-autocomplete-filtering",
+      "search-suggestions-and-bookmarks"},
+ };
++const FeatureEntry::Choice kCloseWindowWithLastTab[] = {
++    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
++    {"Never",
++     "close-window-with-last-tab",
++     "never"},
++};
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_CHOICES_H_
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -52,4 +52,8 @@
+      "Omnibox Autocomplete Filtering",
+      "Restrict omnibox autocomplete results to search suggestions (if enabled) or search suggestions and bookmarks.  ungoogled-chromium flag.",
+      kOsAll, MULTI_VALUE_TYPE(kOmniboxAutocompleteFiltering)},
++    {"close-window-with-last-tab",
++     "Close window with last tab",
++     "Determines whether a window should close once the last tab is closed.  ungoogled-chromium flag.",
++     kOsDesktop, MULTI_VALUE_TYPE(kCloseWindowWithLastTab)},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-to-configure-extension-downloading.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-configure-extension-downloading.patch
@@ -1,36 +1,6 @@
 # Add extension-mime-request-handling chrome://flag to tweak the behavior of
 # extension MIME types
 
---- a/chrome/browser/about_flags.cc
-+++ b/chrome/browser/about_flags.cc
-@@ -262,6 +262,16 @@ const unsigned kOsDesktop = kOsMac | kOs
- const unsigned kOsAura = kOsWin | kOsLinux | kOsCrOS;
- #endif  // USE_AURA || OS_ANDROID
- 
-+const FeatureEntry::Choice kExtensionHandlingChoices[] = {
-+    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
-+    {"Download as regular file",
-+     "extension-mime-request-handling",
-+     "download-as-regular-file"},
-+    {"Always prompt for install",
-+     "extension-mime-request-handling",
-+     "always-prompt-for-install"},
-+};
-+
- #if defined(USE_AURA)
- const FeatureEntry::Choice kPullToRefreshChoices[] = {
-     {flags_ui::kGenericExperimentChoiceDefault, "", ""},
-@@ -2453,6 +2463,10 @@ const FeatureEntry kFeatureEntries[] = {
- // Include generated flags for flag unexpiry; see //docs/flag_expiry.md and
- // //tools/flags/generate_unexpire_flags.py.
- #include "chrome/browser/unexpire_flags_gen.inc"
-+    {"extension-mime-request-handling",
-+     "Handling of extension MIME type requests",
-+     "Used when deciding how to handle a request for a CRX or User Script MIME type",
-+     kOsAll, MULTI_VALUE_TYPE(kExtensionHandlingChoices)},
-     {"enable-stacked-tab-strip",
-      "Enable stacking in the tab strip",
-      "Forces tabs to be stacked in the tab strip. Otherwise, they follow default behavior.",
 --- a/chrome/browser/download/download_crx_util.cc
 +++ b/chrome/browser/download/download_crx_util.cc
 @@ -6,6 +6,7 @@
@@ -121,3 +91,30 @@
    // No allowed install sites specified, disallow by default.
    if (!global_settings_->has_restricted_install_sources)
      return false;
+--- a/chrome/browser/ungoogled_flag_choices.h
++++ b/chrome/browser/ungoogled_flag_choices.h
+@@ -4,4 +4,13 @@
+ 
+ #ifndef CHROME_BROWSER_UNGOOGLED_FLAG_CHOICES_H_
+ #define CHROME_BROWSER_UNGOOGLED_FLAG_CHOICES_H_
++const FeatureEntry::Choice kExtensionHandlingChoices[] = {
++    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
++    {"Download as regular file",
++     "extension-mime-request-handling",
++     "download-as-regular-file"},
++    {"Always prompt for install",
++     "extension-mime-request-handling",
++     "always-prompt-for-install"},
++};
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_CHOICES_H_
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -12,4 +12,8 @@
+      "Enable stacking in the tab strip",
+      "Forces tabs to be stacked in the tab strip. Otherwise, they follow default behavior.  ungoogled-chromium flag.",
+      kOsAll, SINGLE_VALUE_TYPE("enable-stacked-tab-strip")},
++    {"extension-mime-request-handling",
++     "Handling of extension MIME type requests",
++     "Used when deciding how to handle a request for a CRX or User Script MIME type.  ungoogled-chromium flag.",
++     kOsAll, MULTI_VALUE_TYPE(kExtensionHandlingChoices)},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-to-disable-beforeunload.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-disable-beforeunload.patch
@@ -1,5 +1,16 @@
 # Add --disable-beforeunload to always disable beforeunload JavaScript dialogs
 
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -20,4 +20,8 @@
+      "Disable search engine collection",
+      "Prevents search engines from being added automatically.  ungoogled-chromium flag.",
+      kOsAll, SINGLE_VALUE_TYPE("disable-search-engine-collection")},
++    {"disable-beforeunload",
++     "Disable beforeunload",
++     "Disables JavaScript dialog boxes triggered by beforeunload.  ungoogled-chromium flag.",
++     kOsAll, SINGLE_VALUE_TYPE("disable-beforeunload")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/components/javascript_dialogs/app_modal_dialog_manager.cc
 +++ b/components/javascript_dialogs/app_modal_dialog_manager.cc
 @@ -8,6 +8,7 @@

--- a/patches/extra/ungoogled-chromium/add-flag-to-force-punycode-hostnames.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-force-punycode-hostnames.patch
@@ -1,18 +1,16 @@
 # Add flag to force punycode in hostnames instead of Unicode when displaying Internationalized Domain Names (IDNs) to mitigate homograph attacks
 
---- a/chrome/browser/about_flags.cc
-+++ b/chrome/browser/about_flags.cc
-@@ -2475,6 +2475,10 @@ const FeatureEntry kFeatureEntries[] = {
-      "Disable search engine collection",
-      "Prevents search engines from being added automatically.",
-      kOsAll, SINGLE_VALUE_TYPE("disable-search-engine-collection")},
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -24,4 +24,8 @@
+      "Disable beforeunload",
+      "Disables JavaScript dialog boxes triggered by beforeunload.  ungoogled-chromium flag.",
+      kOsAll, SINGLE_VALUE_TYPE("disable-beforeunload")},
 +    {"force-punycode-hostnames",
 +     "Force punycode hostnames",
-+     "Force punycode in hostnames instead of Unicode when displaying Internationalized Domain Names (IDNs).",
++     "Force punycode in hostnames instead of Unicode when displaying Internationalized Domain Names (IDNs).  ungoogled-chromium flag.",
 +     kOsAll, SINGLE_VALUE_TYPE("force-punycode-hostnames")},
-     {"ignore-gpu-blocklist", flag_descriptions::kIgnoreGpuBlocklistName,
-      flag_descriptions::kIgnoreGpuBlocklistDescription, kOsAll,
-      SINGLE_VALUE_TYPE(switches::kIgnoreGpuBlocklist)},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/components/url_formatter/url_formatter.cc
 +++ b/components/url_formatter/url_formatter.cc
 @@ -8,6 +8,7 @@

--- a/patches/extra/ungoogled-chromium/add-flag-to-hide-crashed-bubble.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-hide-crashed-bubble.patch
@@ -13,3 +13,14 @@
      SessionCrashedBubble::ShowIfNotOffTheRecordProfile(browser);
  
    // The below info bars are only added to the first profile which is launched.
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -32,4 +32,8 @@
+      "Show avatar/people/profile button",
+      "Show avatar/people/profile button in the browser toolbar.  ungoogled-chromium flag.",
+      kOsDesktop, MULTI_VALUE_TYPE(kShowAvatarButtonChoices)},
++    {"hide-crashed-bubble",
++     "Hide crashed bubble",
++     "Hides the bubble box with the message \"Restore Pages? Chromium didn't shut down correctly.\" that shows on startup after the browser did not exit cleanly.  ungoogled-chromium flag.",
++     kOsAll, SINGLE_VALUE_TYPE("hide-crashed-bubble")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-to-scroll-tabs.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-scroll-tabs.patch
@@ -1,34 +1,3 @@
---- a/chrome/browser/about_flags.cc
-+++ b/chrome/browser/about_flags.cc
-@@ -285,6 +285,16 @@ const FeatureEntry::Choice kShowAvatarBu
-      "never"}
- };
- 
-+const FeatureEntry::Choice kScrollEventChangesTab[] = {
-+    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
-+    {"Always",
-+     "scroll-tabs",
-+     "always"},
-+    {"Never",
-+     "scroll-tabs",
-+     "never"}
-+};
-+
- #if defined(USE_AURA)
- const FeatureEntry::Choice kPullToRefreshChoices[] = {
-     {flags_ui::kGenericExperimentChoiceDefault, "", ""},
-@@ -4911,6 +4921,11 @@ const FeatureEntry kFeatureEntries[] = {
-      FEATURE_VALUE_TYPE(
-          autofill::features::kAutofillEnableAccountWalletStorage)},
- 
-+    {"scroll-tabs",
-+     "Scroll switches tab",
-+     "Switch to the left/right tab if the wheel-scroll happens over the tabstrip, or the empty space beside the tabstrip.", kOsDesktop,
-+     MULTI_VALUE_TYPE(kScrollEventChangesTab)},
-+
- #if defined(OS_CHROMEOS)
-     {"enable-zero-state-suggestions",
-      flag_descriptions::kEnableZeroStateSuggestionsName,
 --- a/chrome/browser/ui/views/frame/browser_root_view.cc
 +++ b/chrome/browser/ui/views/frame/browser_root_view.cc
 @@ -9,6 +9,7 @@
@@ -89,3 +58,30 @@
    std::unique_ptr<DropInfo> drop_info_;
  
    base::WeakPtrFactory<BrowserRootView> weak_ptr_factory_{this};
+--- a/chrome/browser/ungoogled_flag_choices.h
++++ b/chrome/browser/ungoogled_flag_choices.h
+@@ -25,4 +25,13 @@ const FeatureEntry::Choice kShowAvatarBu
+      "show-avatar-button",
+      "never"}
+ };
++const FeatureEntry::Choice kScrollEventChangesTab[] = {
++    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
++    {"Always",
++     "scroll-tabs",
++     "always"},
++    {"Never",
++     "scroll-tabs",
++     "never"}
++};
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_CHOICES_H_
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -36,4 +36,8 @@
+      "Hide crashed bubble",
+      "Hides the bubble box with the message \"Restore Pages? Chromium didn't shut down correctly.\" that shows on startup after the browser did not exit cleanly.  ungoogled-chromium flag.",
+      kOsAll, SINGLE_VALUE_TYPE("hide-crashed-bubble")},
++    {"scroll-tabs",
++     "Scroll switches tab",
++     "Switch to the left/right tab if the wheel-scroll happens over the tabstrip, or the empty space beside the tabstrip.  ungoogled-chromium flag.",
++     kOsDesktop, MULTI_VALUE_TYPE(kScrollEventChangesTab)},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-to-show-avatar-button.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-show-avatar-button.patch
@@ -1,37 +1,3 @@
---- a/chrome/browser/about_flags.cc
-+++ b/chrome/browser/about_flags.cc
-@@ -272,6 +272,19 @@ const FeatureEntry::Choice kExtensionHan
-      "always-prompt-for-install"},
- };
- 
-+const FeatureEntry::Choice kShowAvatarButtonChoices[] = {
-+    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
-+    {"Always",
-+     "show-avatar-button",
-+     "always"},
-+    {"Incognito and Guest",
-+     "show-avatar-button",
-+     "incognito-and-guest"},
-+    {"Never",
-+     "show-avatar-button",
-+     "never"}
-+};
-+
- #if defined(USE_AURA)
- const FeatureEntry::Choice kPullToRefreshChoices[] = {
-     {flags_ui::kGenericExperimentChoiceDefault, "", ""},
-@@ -5024,6 +5037,11 @@ const FeatureEntry kFeatureEntries[] = {
-      FEATURE_VALUE_TYPE(arc::kEnableUnifiedAudioFocusFeature)},
- #endif  // defined(OS_CHROMEOS)
- 
-+    {"show-avatar-button",
-+     "Show avatar/people/profile button",
-+     "Show avatar/people/profile button in the browser toolbar", kOsDesktop,
-+     MULTI_VALUE_TYPE(kShowAvatarButtonChoices)},
-+
- #if defined(OS_WIN)
-     {"use-angle", flag_descriptions::kUseAngleName,
-      flag_descriptions::kUseAngleDescription, kOsWin,
 --- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
 +++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
 @@ -233,14 +233,30 @@ void ToolbarView::Init() {
@@ -67,3 +33,33 @@
    if (base::FeatureList::IsEnabled(
            autofill::features::kAutofillEnableToolbarStatusChip)) {
      // The avatar button is contained inside the page-action container and
+--- a/chrome/browser/ungoogled_flag_choices.h
++++ b/chrome/browser/ungoogled_flag_choices.h
+@@ -13,4 +13,16 @@ const FeatureEntry::Choice kExtensionHan
+      "extension-mime-request-handling",
+      "always-prompt-for-install"},
+ };
++const FeatureEntry::Choice kShowAvatarButtonChoices[] = {
++    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
++    {"Always",
++     "show-avatar-button",
++     "always"},
++    {"Incognito and Guest",
++     "show-avatar-button",
++     "incognito-and-guest"},
++    {"Never",
++     "show-avatar-button",
++     "never"}
++};
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_CHOICES_H_
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -28,4 +28,8 @@
+      "Force punycode hostnames",
+      "Force punycode in hostnames instead of Unicode when displaying Internationalized Domain Names (IDNs).  ungoogled-chromium flag.",
+      kOsAll, SINGLE_VALUE_TYPE("force-punycode-hostnames")},
++    {"show-avatar-button",
++     "Show avatar/people/profile button",
++     "Show avatar/people/profile button in the browser toolbar.  ungoogled-chromium flag.",
++     kOsDesktop, MULTI_VALUE_TYPE(kShowAvatarButtonChoices)},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-to-stack-tabs.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-stack-tabs.patch
@@ -1,18 +1,5 @@
 # Add --enable-stacked-tab-strip and --enable-tab-adjust-layout flags to tweak tab strip behavior
 
---- a/chrome/browser/about_flags.cc
-+++ b/chrome/browser/about_flags.cc
-@@ -2453,6 +2453,10 @@ const FeatureEntry kFeatureEntries[] = {
- // Include generated flags for flag unexpiry; see //docs/flag_expiry.md and
- // //tools/flags/generate_unexpire_flags.py.
- #include "chrome/browser/unexpire_flags_gen.inc"
-+    {"enable-stacked-tab-strip",
-+     "Enable stacking in the tab strip",
-+     "Forces tabs to be stacked in the tab strip. Otherwise, they follow default behavior.",
-+     kOsAll, SINGLE_VALUE_TYPE("enable-stacked-tab-strip")},
-     {"ignore-gpu-blocklist", flag_descriptions::kIgnoreGpuBlocklistName,
-      flag_descriptions::kIgnoreGpuBlocklistDescription, kOsAll,
-      SINGLE_VALUE_TYPE(switches::kIgnoreGpuBlocklist)},
 --- a/chrome/browser/ui/views/tabs/browser_tab_strip_controller.cc
 +++ b/chrome/browser/ui/views/tabs/browser_tab_strip_controller.cc
 @@ -77,14 +77,13 @@ using content::WebContents;
@@ -33,3 +20,14 @@
  #endif
  }
  
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -8,4 +8,8 @@
+      "SetIpv6ProbeFalse",
+      "Forces the result of the browser's IPv6 probing (i.e. IPv6 connectivity test) to be unsuccessful. This causes IPv4 addresses to be prioritized over IPv6 addresses. Without this flag, the probing result is set to be successful, which causes IPv6 to be used over IPv4 when possible.  ungoogled-chromium flag.",
+      kOsAll, FEATURE_VALUE_TYPE(net::features::kSetIpv6ProbeFalse)},
++    {"enable-stacked-tab-strip",
++     "Enable stacking in the tab strip",
++     "Forces tabs to be stacked in the tab strip. Otherwise, they follow default behavior.  ungoogled-chromium flag.",
++     kOsAll, SINGLE_VALUE_TYPE("enable-stacked-tab-strip")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-ipv6-probing-option.patch
+++ b/patches/extra/ungoogled-chromium/add-ipv6-probing-option.patch
@@ -1,6 +1,16 @@
 # Disables IPv6 probing and adds an option to change the IPv6 probing result
-# TODO: Consider adding a chrome://flag to set the command-line flag
 
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -4,4 +4,8 @@
+ 
+ #ifndef CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
+ #define CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
++    {"set-ipv6-probe-false",
++     "SetIpv6ProbeFalse",
++     "Forces the result of the browser's IPv6 probing (i.e. IPv6 connectivity test) to be unsuccessful. This causes IPv4 addresses to be prioritized over IPv6 addresses. Without this flag, the probing result is set to be successful, which causes IPv6 to be used over IPv4 when possible.  ungoogled-chromium flag.",
++     kOsAll, FEATURE_VALUE_TYPE(net::features::kSetIpv6ProbeFalse)},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/net/base/features.cc
 +++ b/net/base/features.cc
 @@ -195,5 +195,7 @@ extern const base::FeatureParam<base::Ti

--- a/patches/extra/ungoogled-chromium/add-ungoogled-flag-headers.patch
+++ b/patches/extra/ungoogled-chromium/add-ungoogled-flag-headers.patch
@@ -1,0 +1,54 @@
+--- a/chrome/browser/about_flags.cc
++++ b/chrome/browser/about_flags.cc
+@@ -2449,7 +2449,11 @@ const FeatureEntry::FeatureVariation kSC
+ // calculate and verify checksum.
+ //
+ // When adding a new choice, add it to the end of the list.
++#include "chrome/browser/ungoogled_flag_choices.h"
++#include "chrome/browser/bromite_flag_choices.h"
+ const FeatureEntry kFeatureEntries[] = {
++#include "chrome/browser/ungoogled_flag_entries.h"
++#include "chrome/browser/bromite_flag_entries.h"
+ // Include generated flags for flag unexpiry; see //docs/flag_expiry.md and
+ // //tools/flags/generate_unexpire_flags.py.
+ #include "chrome/browser/unexpire_flags_gen.inc"
+--- /dev/null
++++ b/chrome/browser/bromite_flag_choices.h
+@@ -0,0 +1,7 @@
++// Copyright (c) 2020 The ungoogled-chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_BROMITE_FLAG_CHOICES_H_
++#define CHROME_BROWSER_BROMITE_FLAG_CHOICES_H_
++#endif  // CHROME_BROWSER_BROMITE_FLAG_CHOICES_H_
+--- /dev/null
++++ b/chrome/browser/bromite_flag_entries.h
+@@ -0,0 +1,7 @@
++// Copyright (c) 2020 The ungoogled-chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_BROMITE_FLAG_ENTRIES_H_
++#define CHROME_BROWSER_BROMITE_FLAG_ENTRIES_H_
++#endif  // CHROME_BROWSER_BROMITE_FLAG_ENTRIES_H_
+--- /dev/null
++++ b/chrome/browser/ungoogled_flag_choices.h
+@@ -0,0 +1,7 @@
++// Copyright (c) 2020 The ungoogled-chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_UNGOOGLED_FLAG_CHOICES_H_
++#define CHROME_BROWSER_UNGOOGLED_FLAG_CHOICES_H_
++#endif  // CHROME_BROWSER_UNGOOGLED_FLAG_CHOICES_H_
+--- /dev/null
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -0,0 +1,7 @@
++// Copyright (c) 2020 The ungoogled-chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
++#define CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
++#endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-ungoogled-flag-headers.patch
+++ b/patches/extra/ungoogled-chromium/add-ungoogled-flag-headers.patch
@@ -1,14 +1,16 @@
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -2449,7 +2449,11 @@ const FeatureEntry::FeatureVariation kSC
+@@ -2449,7 +2449,13 @@ const FeatureEntry::FeatureVariation kSC
  // calculate and verify checksum.
  //
  // When adding a new choice, add it to the end of the list.
 +#include "chrome/browser/ungoogled_flag_choices.h"
 +#include "chrome/browser/bromite_flag_choices.h"
++#include "chrome/browser/ungoogled_platform_flag_choices.h"
  const FeatureEntry kFeatureEntries[] = {
 +#include "chrome/browser/ungoogled_flag_entries.h"
 +#include "chrome/browser/bromite_flag_entries.h"
++#include "chrome/browser/ungoogled_platform_flag_entries.h"
  // Include generated flags for flag unexpiry; see //docs/flag_expiry.md and
  // //tools/flags/generate_unexpire_flags.py.
  #include "chrome/browser/unexpire_flags_gen.inc"
@@ -52,3 +54,23 @@
 +#ifndef CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 +#define CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 +#endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
+--- /dev/null
++++ b/chrome/browser/ungoogled_platform_flag_choices.h
+@@ -0,0 +1,7 @@
++// Copyright (c) 2020 The ungoogled-chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_UNGOOGLED_PLATFORM_FLAG_CHOICES_H_
++#define CHROME_BROWSER_UNGOOGLED_PLATFORM_FLAG_CHOICES_H_
++#endif  // CHROME_BROWSER_UNGOOGLED_PLATFORM_FLAG_CHOICES_H_
+--- /dev/null
++++ b/chrome/browser/ungoogled_platform_flag_entries.h
+@@ -0,0 +1,7 @@
++// Copyright (c) 2020 The ungoogled-chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_UNGOOGLED_PLATFORM_FLAG_ENTRIES_H_
++#define CHROME_BROWSER_UNGOOGLED_PLATFORM_FLAG_ENTRIES_H_
++#endif  // CHROME_BROWSER_UNGOOGLED_PLATFORM_FLAG_ENTRIES_H_

--- a/patches/series
+++ b/patches/series
@@ -57,6 +57,7 @@ extra/iridium-browser/updater-disable-auto-update.patch
 extra/iridium-browser/Remove-EV-certificates.patch
 extra/iridium-browser/browser-disable-profile-auto-import-on-first-run.patch
 extra/ungoogled-chromium/add-components-ungoogled.patch
+extra/ungoogled-chromium/add-ungoogled-flag-headers.patch
 extra/ungoogled-chromium/disable-formatting-in-omnibox.patch
 extra/ungoogled-chromium/popups-to-tabs.patch
 extra/ungoogled-chromium/add-ipv6-probing-option.patch


### PR DESCRIPTION
I noticed the TODO comment about adding a flag to `chrome://flags` in `add-ipv6-probing-option.patch` while working on a previous change.  I decided to delay adding the flag and create it's own PR, which has since evolved into this one!  

I've made this a draft for now to get feedback on the implementation and to make sure that this doesn't cause problems for anyone.  I also need to set up a companion PR for the Windows-specific flags.  Not to mention the major version update due in a day or so will require this to be updated anyways.  

# Overview
* Creates flag entries for patches that did not have them previously.  Now all features have `chrome://flags` entries!
* Added "ungoogled-chromium flag" to the end of all flag descriptions.  This makes it easier to differentiate between Chromium flags and ones that have been added by ungoogled-chromium.  It also has the benefit of being able to pull up all the ungoogled-chromiumn flags when searching on the flag page.  
* Updates the flag documentation.  I organized the flags by the platform it's available for and used a table layout for readability.  ([preview](https://github.com/Eloston/ungoogled-chromium/blob/9cdae7734149dfac08dcfc421a616e0b81cad6c5/docs/flags.md))  
* Adds a patch which creates headers to organize flags added by Ungoogled Chromium.  This is where the most significant change happens and will be explained in more detail below.  
* Updates existing patches to use the new headers.  
* Fixes a small bug in `validate_patches.py` that this processes uncovered.
