### PR TITLE
Performance improvements for update_lists.py

### DIFF
--- a/devutils/update_lists.py
+++ b/devutils/update_lists.py
@@ -169,16 +169,14 @@ def should_prune(path, relative_path, unused_patterns):
     unused_patterns is a UnusedPatterns object
     """
     # Match against include patterns
-    for pattern in PRUNING_INCLUDE_PATTERNS:
-        if relative_path.match(pattern):
-            unused_patterns.pruning_include_patterns.discard(pattern)
-            return True
+    for pattern in filter(relative_path.match, PRUNING_INCLUDE_PATTERNS):
+        unused_patterns.pruning_include_patterns.discard(pattern)
+        return True
 
     # Match against exclude patterns
-    for pattern in PRUNING_EXCLUDE_PATTERNS:
-        if Path(str(relative_path).lower()).match(pattern):
-            unused_patterns.pruning_exclude_patterns.discard(pattern)
-            return False
+    for pattern in filter(Path(str(relative_path).lower()).match, PRUNING_EXCLUDE_PATTERNS):
+        unused_patterns.pruning_exclude_patterns.discard(pattern)
+        return False
 
     # Do binary data detection
     with path.open('rb') as file_obj:


### PR DESCRIPTION
Running `update_lists.py` for the last update took around 7m35s on average with my hardware.  I made two changes to improve the performance:

*  I changed the loops in `should_prune` to filters.  It seems that pathlib adds a bit of overhead that becomes more apparent when looped over multiple times.  This change on it's own was enough to reduce the script's run-time on my system to 4m54s!
*  I implemented multiprocessing to the script.  Chromium has a lot files that have to be processed, spreading the work out over multiple cores helps get that accomplished in less time.  This change brought the run-time down to 1m10s!

There's a handful of different ways the multiprocessing can be implemented, but I believe that this is one of the most readable ways to handle it in this instance.  

I made `source_tree` and `search_regex` into globals.  These weren't changed during runtime after being set by the args, so it made sense to me to make them global so they don't have to be passed to each process.  Let me know if you'd prefer to not have them set up that way.  