### PR TITLE
Patch distilled page to have a useable menu

### DIFF
--- a/patches/extra/ungoogled-chromium/fix-distilled-icons.patch
+++ b/patches/extra/ungoogled-chromium/fix-distilled-icons.patch
@@ -1,0 +1,14 @@
+--- a/components/dom_distiller/core/css/distilledpage.css
++++ b/components/dom_distiller/core/css/distilledpage.css
+@@ -28,6 +28,11 @@
+   box-sizing: border-box;
+ }
+ 
++.material-icons {
++  font-family: Material Icons;
++  font-style: normal !important;
++}
++
+ /* Remove all margins and padding from certain element and add word wrap. */
+ 
+ blockquote,

--- a/patches/series
+++ b/patches/series
@@ -84,6 +84,7 @@ extra/ungoogled-chromium/add-flag-to-close-window-with-last-tab.patch
 extra/ungoogled-chromium/add-flag-to-convert-popups-to-tabs.patch
 extra/ungoogled-chromium/add-extra-channel-info.patch
 extra/ungoogled-chromium/prepopulated-search-engines.patch
+extra/ungoogled-chromium/fix-distilled-icons.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch


### PR DESCRIPTION
### What does this do?
The gruvbox-dark colorscheme was missing from the distilled-page themes. I added it as 'gruv'.
I also noticed that the topmenu was completely glitched on my system (Probably due to Ungoogled Chromium substituting Google-Api-Urls).
![20-38-31](https://user-images.githubusercontent.com/44272603/101994836-e4d01c80-3cc5-11eb-94bf-d3978c39ea7c.png)

The first patch / commit transforms it to look like this:
![image](https://user-images.githubusercontent.com/44272603/101994861-252f9a80-3cc6-11eb-87a8-0a38f9dba362.png)

The second patch adds the gruvbox-dark colorscheme to the options: (https://android.stackexchange.com/questions/218970/enable-chromes-reader-view-manually-when-it-isnt-offered)
![image](https://user-images.githubusercontent.com/44272603/101994934-8ce5e580-3cc6-11eb-9328-737ab21f311d.png)

I might also do a followup PR that adds both an additional slider (width) and a flag to always show the distilled icon in the urlbar, since chromiums detection mechanism doesn't work well.