### PR TITLE
Add Fedora repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ These binaries are known as **contributor binaries**.
 
 Also, ungoogled-chromium is available in several **software repositories**:
 
-* Android: Available via a custom [F-Droid](https://f-droid.org/) repo. [See instructions in ungoogled-chromium-android](https://github.com/wchen342/ungoogled-chromium-android#f-droid-repository)
+* Android: Available via a custom [F-Droid](https://f-droid.org/) repo. [See instructions in ungoogled-chromium-android](https://github.com/ungoogled-software/ungoogled-chromium-android#f-droid-repository)
 * Arch: Available in [AUR](https://aur.archlinux.org/) as [`ungoogled-chromium`](https://aur.archlinux.org/packages/ungoogled-chromium/)
 * Debian & Ubuntu: Available in OBS, find your [distribution specific instructions](//github.com/ungoogled-software/ungoogled-chromium-debian) in the Installing section
-* Fedora: Available in [RPM Fusion](https://rpmfusion.org/Configuration) as `chromium-browser-privacy`. Also available in OBS, by following [instructions](//github.com/wchen342/ungoogled-chromium-fedora) in the downloads section
+* Fedora: Available in [RPM Fusion](https://rpmfusion.org/Configuration) as `chromium-browser-privacy`. Also available in OBS, by following [instructions](//github.com/ungoogled-software/ungoogled-chromium-fedora) in the downloads section
 * Gentoo: Available in [`::pf4public`](https://github.com/PF4Public/gentoo-overlay) overlay as [`ungoogled-chromium`](https://github.com/PF4Public/gentoo-overlay/tree/master/www-client/ungoogled-chromium) ebuild
 * macOS: Available in [Homebrew](https://brew.sh/) as [`eloston-chromium`](https://formulae.brew.sh/cask/eloston-chromium). Just run `brew fetch --cask eloston-chromium` and `brew install --cask eloston-chromium`. Chromium will appear in your `/Applications` directory.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Also, ungoogled-chromium is available in several **software repositories**:
 * Android: Available via a custom [F-Droid](https://f-droid.org/) repo. [See instructions in ungoogled-chromium-android](https://github.com/wchen342/ungoogled-chromium-android#f-droid-repository)
 * Arch: Available in [AUR](https://aur.archlinux.org/) as [`ungoogled-chromium`](https://aur.archlinux.org/packages/ungoogled-chromium/)
 * Debian & Ubuntu: Available in OBS, find your [distribution specific instructions](//github.com/ungoogled-software/ungoogled-chromium-debian) in the Installing section
-* Fedora: Available in [RPM Fusion](https://rpmfusion.org) as `chromium-browser-privacy`
+* Fedora: Available in [RPM Fusion](https://rpmfusion.org/Configuration) as `chromium-browser-privacy`. Also available in OBS, by following [instructions](//github.com/wchen342/ungoogled-chromium-fedora) in the downloads section
 * Gentoo: Available in [`::pf4public`](https://github.com/PF4Public/gentoo-overlay) overlay as [`ungoogled-chromium`](https://github.com/PF4Public/gentoo-overlay/tree/master/www-client/ungoogled-chromium) ebuild
 * macOS: Available in [Homebrew](https://brew.sh/) as [`eloston-chromium`](https://formulae.brew.sh/cask/eloston-chromium). Just run `brew fetch --cask eloston-chromium` and `brew install --cask eloston-chromium`. Chromium will appear in your `/Applications` directory.
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -5,6 +5,7 @@ This page lists platforms officially supported by ungoogled-chromium, and their 
 * Android: [ungoogled-chromium-android](//github.com/ungoogled-software/ungoogled-chromium-android)
 * Arch Linux: [ungoogled-chromium-archlinux](//github.com/ungoogled-software/ungoogled-chromium-archlinux)
 * Debian, Ubuntu, and derivatives: [ungoogled-chromium-debian](//github.com/ungoogled-software/ungoogled-chromium-debian)
+* Fedora: [ungoogled-chromium-fedora](//github.com/wchen342/ungoogled-chromium-fedora)
 * Portable Linux (for any Linux distro): [ungoogled-chromium-portablelinux](//github.com/ungoogled-software/ungoogled-chromium-portablelinux)
 * Windows: [ungoogled-chromium-windows](//github.com/ungoogled-software/ungoogled-chromium-windows)
 * macOS: [ungoogled-chromium-macos](//github.com/ungoogled-software/ungoogled-chromium-macos)

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -5,7 +5,7 @@ This page lists platforms officially supported by ungoogled-chromium, and their 
 * Android: [ungoogled-chromium-android](//github.com/ungoogled-software/ungoogled-chromium-android)
 * Arch Linux: [ungoogled-chromium-archlinux](//github.com/ungoogled-software/ungoogled-chromium-archlinux)
 * Debian, Ubuntu, and derivatives: [ungoogled-chromium-debian](//github.com/ungoogled-software/ungoogled-chromium-debian)
-* Fedora: [ungoogled-chromium-fedora](//github.com/wchen342/ungoogled-chromium-fedora)
+* Fedora: [ungoogled-chromium-fedora](//github.com/ungoogled-software/ungoogled-chromium-fedora)
 * Portable Linux (for any Linux distro): [ungoogled-chromium-portablelinux](//github.com/ungoogled-software/ungoogled-chromium-portablelinux)
 * Windows: [ungoogled-chromium-windows](//github.com/ungoogled-software/ungoogled-chromium-windows)
 * macOS: [ungoogled-chromium-macos](//github.com/ungoogled-software/ungoogled-chromium-macos)


### PR DESCRIPTION
I created a repo for Fedora and rewrote the `.spec` file using the upstream Fedora `chromium` package, which is a little different from the one in `chromium-privacy-browser`.
Currently it is being built on OBS so it can potentially support OpenSUSE Tumbleweed too, but I do not have a test system so I will keep it in Fedora for now.
If this is accepted then I will transfer the fedora repo into `ungoogled-software`.