### PR TITLE
Remove android specific files from pruning list

### DIFF
--- a/devutils/update_lists.py
+++ b/devutils/update_lists.py
@@ -57,6 +57,12 @@ PRUNING_EXCLUDE_PATTERNS = [
     # Exclusion for required prebuilt object for Windows arm64 builds
     'third_party/crashpad/crashpad/util/misc/capture_context_win_arm64.obj',
     'third_party/icu/common/icudtl.dat', # Exclusion for ICU data
+    # Exclusion for Android
+    'build/android/chromium-debug.keystore',
+    'third_party/icu/android/icudtl.dat',
+    'third_party/icu/android_small/icudtl.dat',
+    'third_party/icu/common/icudtb.dat',
+    'third_party/jetifier_standalone/lib/jetifier-standalone.jar',
     # Exclusions for safe file extensions
     '*.avif',
     '*.ttf',

--- a/pruning.list
+++ b/pruning.list
@@ -26,7 +26,6 @@ base/test/data/tzdata/2019a/44/le/metaZones.res
 base/test/data/tzdata/2019a/44/le/timezoneTypes.res
 base/test/data/tzdata/2019a/44/le/zoneinfo64.res
 build/android/CheckInstallApk-debug.apk
-build/android/chromium-debug.keystore
 build/android/stacktrace/java_deobfuscate.jar
 build/android/tests/symbolize/liba.so
 build/android/tests/symbolize/libb.so
@@ -15582,12 +15581,9 @@ third_party/hyphenation-patterns/hyb/hyph-ta.hyb
 third_party/hyphenation-patterns/hyb/hyph-te.hyb
 third_party/hyphenation-patterns/hyb/hyph-tk.hyb
 third_party/hyphenation-patterns/hyb/hyph-und-ethi.hyb
-third_party/icu/android/icudtl.dat
-third_party/icu/android_small/icudtl.dat
 third_party/icu/android_small/icudtl_extra.dat
 third_party/icu/cast/icudtl.dat
 third_party/icu/chromeos/icudtl.dat
-third_party/icu/common/icudtb.dat
 third_party/icu/flutter/icudtl.dat
 third_party/icu/ios/icudtl.dat
 third_party/icu/source/data/in/coll/ucadata-implicithan.icu
@@ -15605,7 +15601,6 @@ third_party/icu/source/data/in/uts46.nrm
 third_party/icu/tzres/metaZones.res
 third_party/icu/tzres/timezoneTypes.res
 third_party/icu/tzres/zoneinfo64.res
-third_party/jetifier_standalone/lib/jetifier-standalone.jar
 third_party/libavif/src/tests/data/cosmos1650_yuv444_10bpc_p3pq.y4m
 third_party/libavif/src/tests/data/kodim03_yuv420_8bpc.y4m
 third_party/libavif/src/tests/data/kodim23_yuv420_8bpc.y4m


### PR DESCRIPTION
Remove some files needed for Android from `pruning.list`.
Solves #1274.
