### PR TITLE
Now available on the regular Flathub repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Also, ungoogled-chromium is available in several **software repositories**:
 
 If your GNU/Linux distribution is not listed, there are distro-independent builds available via the following **package managers**:
 
-* Flatpak: Available in the Flathub [`beta`](https://flathub.org/beta-repo/flathub-beta.flatpakrepo) repo as `com.github.Eloston.UngoogledChromium`
+* Flatpak: Available in the Flathub repo as `com.github.Eloston.UngoogledChromium`
 * GNU Guix: Available as `ungoogled-chromium`
 * NixOS/nixpkgs: Available as `ungoogled-chromium`
 


### PR DESCRIPTION
There is no need to enable the beta repo anymore.

Edit: also note that I will no longer update the beta repo because I don't want to build ungoogled twice. So by using the beta repo you'd be using an older chromium 
