### PR TITLE
Follow-up for Chromium 88

### DIFF
--- a/patches/core/ungoogled-chromium/fix-building-without-safebrowsing.patch
+++ b/patches/core/ungoogled-chromium/fix-building-without-safebrowsing.patch
@@ -131,7 +131,23 @@
    if (!IsRealtimeReportingEnabled())
      return;
  
-@@ -497,6 +504,7 @@ void SafeBrowsingPrivateEventRouter::OnD
+@@ -434,6 +441,7 @@ void SafeBrowsingPrivateEventRouter::OnA
+     OnSensitiveDataEvent(url, file_name, download_digest_sha256, mime_type,
+                          trigger, result, content_size, event_result);
+   }
++#endif // FULL_SAFE_BROWSING
+ }
+ 
+ void SafeBrowsingPrivateEventRouter::OnDangerousDeepScanningResult(
+@@ -448,6 +456,7 @@ void SafeBrowsingPrivateEventRouter::OnD
+     const std::string& malware_family,
+     const std::string& malware_category,
+     const std::string& evidence_locker_filepath) {
++#if defined(FULL_SAFE_BROWSING)
+   if (!IsRealtimeReportingEnabled())
+     return;
+ 
+@@ -497,6 +506,7 @@ void SafeBrowsingPrivateEventRouter::OnD
            url.spec(), file_name, download_digest_sha256, GetProfileUserName(),
            threat_type, mime_type, trigger, content_size, event_result,
            malware_family, malware_category, evidence_locker_filepath));
@@ -139,7 +155,7 @@
  }
  
  void SafeBrowsingPrivateEventRouter::OnSensitiveDataEvent(
-@@ -508,6 +516,7 @@ void SafeBrowsingPrivateEventRouter::OnS
+@@ -508,6 +518,7 @@ void SafeBrowsingPrivateEventRouter::OnS
      const enterprise_connectors::ContentAnalysisResponse::Result& result,
      const int64_t content_size,
      safe_browsing::EventResult event_result) {
@@ -147,7 +163,7 @@
    if (!IsRealtimeReportingEnabled())
      return;
  
-@@ -553,6 +562,7 @@ void SafeBrowsingPrivateEventRouter::OnS
+@@ -553,6 +564,7 @@ void SafeBrowsingPrivateEventRouter::OnS
            result, url.spec(), file_name, download_digest_sha256,
            GetProfileUserName(), mime_type, trigger, content_size,
            event_result));
@@ -155,7 +171,7 @@
  }
  
  void SafeBrowsingPrivateEventRouter::OnAnalysisConnectorWarningBypassed(
-@@ -564,6 +574,7 @@ void SafeBrowsingPrivateEventRouter::OnA
+@@ -564,6 +576,7 @@ void SafeBrowsingPrivateEventRouter::OnA
      safe_browsing::DeepScanAccessPoint access_point,
      const enterprise_connectors::ContentAnalysisResponse::Result& result,
      const int64_t content_size) {
@@ -163,7 +179,7 @@
    if (!IsRealtimeReportingEnabled())
      return;
  
-@@ -608,6 +619,7 @@ void SafeBrowsingPrivateEventRouter::OnA
+@@ -608,6 +621,7 @@ void SafeBrowsingPrivateEventRouter::OnA
            result, url.spec(), file_name, download_digest_sha256,
            GetProfileUserName(), mime_type, trigger, access_point,
            content_size));
@@ -171,7 +187,7 @@
  }
  
  void SafeBrowsingPrivateEventRouter::OnUnscannedFileEvent(
-@@ -620,6 +632,7 @@ void SafeBrowsingPrivateEventRouter::OnU
+@@ -620,6 +634,7 @@ void SafeBrowsingPrivateEventRouter::OnU
      const std::string& reason,
      const int64_t content_size,
      safe_browsing::EventResult event_result) {
@@ -179,7 +195,7 @@
    if (!IsRealtimeReportingEnabled())
      return;
  
-@@ -659,6 +672,7 @@ void SafeBrowsingPrivateEventRouter::OnU
+@@ -659,6 +674,7 @@ void SafeBrowsingPrivateEventRouter::OnU
            url.spec(), file_name, download_digest_sha256, GetProfileUserName(),
            mime_type, trigger, access_point, reason, content_size,
            event_result));
@@ -187,7 +203,7 @@
  }
  
  void SafeBrowsingPrivateEventRouter::OnDangerousDownloadEvent(
-@@ -669,6 +683,7 @@ void SafeBrowsingPrivateEventRouter::OnD
+@@ -669,6 +685,7 @@ void SafeBrowsingPrivateEventRouter::OnD
      const std::string& mime_type,
      const int64_t content_size,
      safe_browsing::EventResult event_result) {
@@ -195,7 +211,7 @@
    if (!IsRealtimeReportingEnabled())
      return;
  
-@@ -703,6 +718,7 @@ void SafeBrowsingPrivateEventRouter::OnD
+@@ -703,6 +720,7 @@ void SafeBrowsingPrivateEventRouter::OnD
            },
            url.spec(), file_name, download_digest_sha256, GetProfileUserName(),
            threat_type, mime_type, content_size, event_result));
@@ -203,7 +219,7 @@
  }
  
  void SafeBrowsingPrivateEventRouter::OnDangerousDownloadWarningBypassed(
-@@ -712,6 +728,7 @@ void SafeBrowsingPrivateEventRouter::OnD
+@@ -712,6 +730,7 @@ void SafeBrowsingPrivateEventRouter::OnD
      const std::string& threat_type,
      const std::string& mime_type,
      const int64_t content_size) {
@@ -211,7 +227,7 @@
    if (!IsRealtimeReportingEnabled())
      return;
  
-@@ -745,6 +762,7 @@ void SafeBrowsingPrivateEventRouter::OnD
+@@ -745,6 +764,7 @@ void SafeBrowsingPrivateEventRouter::OnD
            },
            url.spec(), file_name, download_digest_sha256, GetProfileUserName(),
            threat_type, mime_type, content_size));
@@ -219,7 +235,7 @@
  }
  
  // static
-@@ -970,7 +988,11 @@ void SafeBrowsingPrivateEventRouter::Rep
+@@ -970,7 +990,11 @@ void SafeBrowsingPrivateEventRouter::Rep
  }
  
  std::string SafeBrowsingPrivateEventRouter::GetProfileUserName() const {
@@ -1049,7 +1065,7 @@
        scoped_refptr<NativeFileSystemManagerImpl> manager,
 --- a/content/public/browser/native_file_system_permission_context.h
 +++ b/content/public/browser/native_file_system_permission_context.h
-@@ -99,12 +99,6 @@ class NativeFileSystemPermissionContext
+@@ -99,12 +99,6 @@ class NativeFileSystemPermissionContext 
        base::OnceCallback<void(SensitiveDirectoryResult)> callback) = 0;
  
    enum class AfterWriteCheckResult { kAllow, kBlock };

--- a/patches/core/ungoogled-chromium/remove-unused-preferences-fields.patch
+++ b/patches/core/ungoogled-chromium/remove-unused-preferences-fields.patch
@@ -361,7 +361,7 @@
  #include "components/spellcheck/browser/pref_names.h"
  #include "components/translate/core/browser/translate_pref_names.h"
  #include "extensions/browser/extension_pref_value_map.h"
-@@ -116,11 +115,6 @@ const PrefMappingEntry kPrefMapping[] =
+@@ -116,11 +115,6 @@ const PrefMappingEntry kPrefMapping[] = 
       APIPermission::kPrivacy},
      {"doNotTrackEnabled", prefs::kEnableDoNotTrack, APIPermission::kPrivacy,
       APIPermission::kPrivacy},
@@ -455,7 +455,7 @@
  #include "components/signin/public/identity_manager/identity_manager.h"
  #include "content/public/browser/browser_context.h"
  #include "extensions/browser/event_router.h"
-@@ -919,18 +918,6 @@ bool SafeBrowsingPrivateEventRouter::IsR
+@@ -921,18 +920,6 @@ bool SafeBrowsingPrivateEventRouter::IsR
  
  void SafeBrowsingPrivateEventRouter::IfAuthorized(
      base::OnceCallback<void(bool)> cont) {
@@ -1596,7 +1596,7 @@
    if (!profile_)
 --- a/chrome/browser/safe_browsing/chrome_password_protection_service.h
 +++ b/chrome/browser/safe_browsing/chrome_password_protection_service.h
-@@ -216,13 +216,6 @@ class ChromePasswordProtectionService :
+@@ -216,13 +216,6 @@ class ChromePasswordProtectionService : 
    bool UserClickedThroughSBInterstitial(
        content::WebContents* web_contents) override;
  
@@ -1734,7 +1734,7 @@
  
  namespace settings_api = extensions::api::settings_private;
  
-@@ -18,21 +17,6 @@ const char kGeneratedSafeBrowsingPref[]
+@@ -18,21 +17,6 @@ const char kGeneratedSafeBrowsingPref[] 
  GeneratedSafeBrowsingPref::GeneratedSafeBrowsingPref(Profile* profile)
      : profile_(profile) {
    user_prefs_registrar_.Init(profile->GetPrefs());
@@ -2467,7 +2467,7 @@
  // static
 --- a/chrome/browser/ui/browser_command_controller.h
 +++ b/chrome/browser/ui/browser_command_controller.h
-@@ -208,7 +208,6 @@ class BrowserCommandController : public
+@@ -208,7 +208,6 @@ class BrowserCommandController : public 
  
    PrefChangeRegistrar profile_pref_registrar_;
    PrefChangeRegistrar local_pref_registrar_;
@@ -2944,7 +2944,7 @@
  #include "components/strings/grit/components_strings.h"
  #include "content/public/browser/web_ui.h"
  #include "content/public/browser/web_ui_data_source.h"
-@@ -108,9 +107,7 @@ void SigninErrorUI::Initialize(Browser*
+@@ -108,9 +107,7 @@ void SigninErrorUI::Initialize(Browser* 
    if (is_profile_blocked) {
      source->AddLocalizedString("profileBlockedMessage",
                                 IDS_OLD_PROFILES_DISABLED_MESSAGE);
@@ -4727,7 +4727,7 @@
        primary_account_manager->GetAuthenticatedAccountInfo();
 --- a/components/signin/internal/identity_manager/primary_account_policy_manager_impl.h
 +++ b/components/signin/internal/identity_manager/primary_account_policy_manager_impl.h
-@@ -50,9 +50,6 @@ class PrimaryAccountPolicyManagerImpl :
+@@ -50,9 +50,6 @@ class PrimaryAccountPolicyManagerImpl : 
    // profile-specific local prefs (like kGoogleServicesUsernamePattern).
    PrefChangeRegistrar local_state_pref_registrar_;
  

--- a/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
+++ b/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
@@ -25,13 +25,6 @@
          <div class="separator"></div>
          <a role="menuitem" id="clear-browsing-data"
              href="chrome://settings/clearBrowserData"
-@@ -131,4 +126,4 @@
-         <iron-icon icon="cr:info-outline"></iron-icon>
-         <div>$i18nRaw{sidebarFooter}</div>
-       </div>
--    </div>
-\ No newline at end of file
-+    </div>
 --- a/chrome/browser/resources/settings/a11y_page/a11y_page.html
 +++ b/chrome/browser/resources/settings/a11y_page/a11y_page.html
 @@ -56,10 +56,6 @@


### PR DESCRIPTION
During my review of #1342, I identified two things that didn't directly effect current browser functionality but could cause issues down the road:

1. `remove-unneeded-ui.patch` has `\ No newline at end of file` *before* the end of `chrome/browser/resources/history/side_bar.html`.
2. A `#if defined(FULL_SAFE_BROWSING)` in `fix-building-without-safebrowsing.patch` got moved such that there is no implementation for `SafeBrowsingPrivateEventRouter::OnDangerousDeepScanningResult()`; this appears to not cause issues currently, but could cause linker errors in the future.

This pull request addresses both of these nitpicks; I have compiled ungoogled-chromium with these changes and it is running well.