### PR TITLE
Changes to omnibox filtering to add chrome pages

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -20,7 +20,7 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--fingerprinting-client-rects-noise` | (Added flag to Bromite feature) Implements fingerprinting deception of JS APIs `getClientRects()` and `getBoundingClientRect()` by scaling their output values with a random factor in the range -0.0003% to 0.0003%, which are recomputed for every document instantiation.
   `--hide-crashed-bubble` | Hides the bubble box with the message "Restore Pages? Chromium didn't shut down correctly." that shows on startup after the browser did not exit cleanly.
   `--max-connections-per-host` | (from Bromite) Configure the maximum allowed connections per host. Valid values are `6` and `15`
-  `--omnibox-autocomplete-filtering` | Restrict omnibox autocomplete results to search suggestions (if enabled) or search suggestions and bookmarks. The type of filtering is determined by the values `search-suggestions-only` and `search-suggestions-and-bookmarks`, respectively.
+  `--omnibox-autocomplete-filtering` | Restrict omnibox autocomplete results to a combination of search suggestions (if enabled), bookmarks, and internal chrome pages.  Accepts `search`, `search-bookmarks`, `search-chrome`, and `search-bookmarks-chrome`.
 
 - ### Available only on desktop
 

--- a/patches/extra/ungoogled-chromium/add-flag-for-omnibox-autocomplete-filtering.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-omnibox-autocomplete-filtering.patch
@@ -1,6 +1,6 @@
 --- a/chrome/browser/ungoogled_flag_choices.h
 +++ b/chrome/browser/ungoogled_flag_choices.h
-@@ -45,4 +45,13 @@ const FeatureEntry::Choice kBookmarkBarN
+@@ -45,4 +45,19 @@ const FeatureEntry::Choice kBookmarkBarN
       "bookmark-bar-ntp",
       "never"},
  };
@@ -8,10 +8,16 @@
 +    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
 +    {"Search suggestions only",
 +     "omnibox-autocomplete-filtering",
-+     "search-suggestions-only"},
++     "search"},
 +    {"Search suggestions and bookmarks",
 +     "omnibox-autocomplete-filtering",
-+     "search-suggestions-and-bookmarks"},
++     "search-bookmarks"},
++    {"Search suggestions and internal chrome pages",
++     "omnibox-autocomplete-filtering",
++     "search-chrome"},
++    {"Search suggestions, bookmarks, and internal chrome pages",
++     "omnibox-autocomplete-filtering",
++     "search-bookmarks-chrome"},
 +};
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_CHOICES_H_
 --- a/chrome/browser/ungoogled_flag_entries.h
@@ -22,7 +28,7 @@
       kOsDesktop, MULTI_VALUE_TYPE(kBookmarkBarNewTab)},
 +    {"omnibox-autocomplete-filtering",
 +     "Omnibox Autocomplete Filtering",
-+     "Restrict omnibox autocomplete results to search suggestions (if enabled) or search suggestions and bookmarks.  ungoogled-chromium flag.",
++     "Restrict omnibox autocomplete results to a combination of search suggestions (if enabled), bookmarks, and internal chrome pages.  ungoogled-chromium flag.",
 +     kOsAll, MULTI_VALUE_TYPE(kOmniboxAutocompleteFiltering)},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/components/omnibox/browser/autocomplete_controller.cc
@@ -35,48 +41,29 @@
  #include "base/feature_list.h"
  #include "base/format_macros.h"
  #include "base/metrics/histogram.h"
-@@ -248,11 +249,31 @@ AutocompleteController::AutocompleteCont
-       first_query_(true),
+@@ -249,6 +250,15 @@ AutocompleteController::AutocompleteCont
        search_service_worker_signal_sent_(false),
        template_url_service_(provider_client_->GetTemplateURLService()) {
-+  const std::string flag_value =
-+    base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("omnibox-autocomplete-filtering");
    provider_types &= ~OmniboxFieldTrial::GetDisabledProviderTypes();
--  if (provider_types & AutocompleteProvider::TYPE_BOOKMARK)
-+  if (provider_types & AutocompleteProvider::TYPE_BOOKMARK && flag_value != "search-suggestions-only")
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("omnibox-autocomplete-filtering")) {
++    const std::string flag_value = base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("omnibox-autocomplete-filtering");
++    provider_types &= AutocompleteProvider::TYPE_KEYWORD | AutocompleteProvider::TYPE_SEARCH |
++        AutocompleteProvider::TYPE_HISTORY_URL | AutocompleteProvider::TYPE_BOOKMARK | AutocompleteProvider::TYPE_BUILTIN;
++    if (!base::Contains(flag_value, "bookmarks"))
++      provider_types &= ~AutocompleteProvider::TYPE_BOOKMARK;
++    if (!base::Contains(flag_value, "chrome"))
++      provider_types &= ~AutocompleteProvider::TYPE_BUILTIN;
++  }
+   if (provider_types & AutocompleteProvider::TYPE_BOOKMARK)
      providers_.push_back(new BookmarkProvider(provider_client_.get()));
    if (provider_types & AutocompleteProvider::TYPE_BUILTIN)
-     providers_.push_back(new BuiltinProvider(provider_client_.get()));
-+  if (flag_value == "search-suggestions-only" || flag_value == "search-suggestions-and-bookmarks") {
-+    if (provider_types & AutocompleteProvider::TYPE_KEYWORD) {
-+      keyword_provider_ = new KeywordProvider(provider_client_.get(), this);
-+      providers_.push_back(keyword_provider_);
-+    }
-+    if (provider_types & AutocompleteProvider::TYPE_SEARCH) {
-+      search_provider_ = new SearchProvider(provider_client_.get(), this);
-+      providers_.push_back(search_provider_);
-+    }
-+    if (provider_types & AutocompleteProvider::TYPE_HISTORY_URL) {
-+      history_url_provider_ = new HistoryURLProvider(provider_client_.get(), this);
-+      if (provider_types & AutocompleteProvider::TYPE_HISTORY_URL)
-+        providers_.push_back(history_url_provider_);
-+    }
-+    base::trace_event::MemoryDumpManager::GetInstance()->RegisterDumpProvider(
-+        this, "AutocompleteController", base::ThreadTaskRunnerHandle::Get());
-+    return;
-+  }
-   if (provider_types & AutocompleteProvider::TYPE_HISTORY_QUICK)
-     providers_.push_back(new HistoryQuickProvider(provider_client_.get()));
-   if (provider_types & AutocompleteProvider::TYPE_KEYWORD) {
 --- a/components/omnibox/browser/history_url_provider.cc
 +++ b/components/omnibox/browser/history_url_provider.cc
-@@ -551,6 +551,11 @@ void HistoryURLProvider::Start(const Aut
+@@ -551,6 +551,9 @@ void HistoryURLProvider::Start(const Aut
    if (fixed_up_input.type() != metrics::OmniboxInputType::QUERY)
      matches_.push_back(what_you_typed_match);
  
-+  const std::string flag_value =
-+    base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("omnibox-autocomplete-filtering");
-+  if (flag_value == "search-suggestions-only" || flag_value == "search-suggestions-and-bookmarks")
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("omnibox-autocomplete-filtering"))
 +    return;
 +
    // We'll need the history service to run both passes, so try to obtain it.
@@ -92,15 +79,32 @@
  #include "base/feature_list.h"
  #include "base/i18n/break_iterator.h"
  #include "base/i18n/case_conversion.h"
-@@ -646,6 +647,11 @@ void SearchProvider::Run(bool query_is_p
+@@ -646,6 +647,9 @@ void SearchProvider::Run(bool query_is_p
  }
  
  void SearchProvider::DoHistoryQuery(bool minimal_changes) {
-+  const std::string flag_value =
-+    base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("omnibox-autocomplete-filtering");
-+  if (flag_value == "search-suggestions-only" || flag_value == "search-suggestions-and-bookmarks")
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("omnibox-autocomplete-filtering"))
 +    return;
 +
    // The history query results are synchronous, so if minimal_changes is true,
    // we still have the last results and don't need to do anything.
    if (minimal_changes)
+--- a/components/url_formatter/url_fixer.cc
++++ b/components/url_formatter/url_fixer.cc
+@@ -9,6 +9,7 @@
+ #include <algorithm>
+ 
+ #include "base/check_op.h"
++#include "base/command_line.h"
+ #include "base/files/file_path.h"
+ #include "base/files/file_util.h"
+ #include "base/strings/string_number_conversions.h"
+@@ -605,6 +606,8 @@ GURL FixupURL(const std::string& text, c
+ 
+     FixupHost(trimmed, parts.host, parts.scheme.is_valid(), desired_tld, &url);
+     if (chrome_url && !parts.host.is_valid())
++     if (!base::CommandLine::ForCurrentProcess()->HasSwitch("omnibox-autocomplete-filtering") ||
++         base::Contains(base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("omnibox-autocomplete-filtering"), "chrome"))
+       url.append(kChromeUIDefaultHost);
+     FixupPort(trimmed, parts.port, &url);
+     FixupPath(trimmed, parts.path, &url);

--- a/patches/extra/ungoogled-chromium/add-flag-to-close-window-with-last-tab.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-close-window-with-last-tab.patch
@@ -21,9 +21,9 @@
    if (closing_all) {
 --- a/chrome/browser/ungoogled_flag_choices.h
 +++ b/chrome/browser/ungoogled_flag_choices.h
-@@ -54,4 +54,10 @@ const FeatureEntry::Choice kOmniboxAutoc
+@@ -60,4 +60,10 @@ const FeatureEntry::Choice kOmniboxAutoc
       "omnibox-autocomplete-filtering",
-      "search-suggestions-and-bookmarks"},
+      "search-bookmarks-chrome"},
  };
 +const FeatureEntry::Choice kCloseWindowWithLastTab[] = {
 +    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
@@ -36,7 +36,7 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -52,4 +52,8 @@
       "Omnibox Autocomplete Filtering",
-      "Restrict omnibox autocomplete results to search suggestions (if enabled) or search suggestions and bookmarks.  ungoogled-chromium flag.",
+      "Restrict omnibox autocomplete results to a combination of search suggestions (if enabled), bookmarks, and internal chrome pages.  ungoogled-chromium flag.",
       kOsAll, MULTI_VALUE_TYPE(kOmniboxAutocompleteFiltering)},
 +    {"close-window-with-last-tab",
 +     "Close window with last tab",


### PR DESCRIPTION
This PR addresses #1356 by updating `add-flag-for-omnibox-autocomplete-filtering.patch` to include options for internal chrome pages.  

This flag had two options:  `search-suggestions-only` and `search-suggestions-and-bookmarks`
Those options have been changed to allow for diferent combinations:  `search`, `search-bookmarks`, `search-chrome`, and `search-bookmarks-chrome`

### Detail:

* `autocomplete_controller.cc`:  Since there's more than two options now it's better to change `provider_types` rather than conditionally branching based on the flag's value.  The enabled providers can vary, so rather than setting them directly this will use the existing state of the required providers and then remove the ones we don't need.  
Extra info:  [Default Providers](https://source.chromium.org/chromium/chromium/src/+/refs/tags/88.0.4324.146:components/omnibox/browser/autocomplete_classifier.cc;l=41), [Provider type positions](https://source.chromium.org/chromium/chromium/src/+/refs/tags/88.0.4324.146:components/omnibox/browser/autocomplete_provider.h;l=140)
Using `Contains` allows the old flags to continue to function, though chrome pages would be excluded until the user updates the flag to opt in to them.  

* `history_url_provider.cc` and `search_provider.cc`:  These have been updated to check if the flag is set rather than explicitly checking for the specific flag values.  

* `url_fixer.cc`:  Even with the chrome pages removed from suggestions there would still be a suggestion for `chrome://version/`.  This is due to the URL fixer adding the value when interpreting the input as a chrome URL.  
