### PR TITLE
add filter to compute_lists source_tree.rglob('*')

### DIFF
--- a/devutils/update_lists.py
+++ b/devutils/update_lists.py
@@ -298,7 +298,7 @@ def compute_lists(source_tree, search_regex, processes):
     with Pool(processes) as procpool:
         returned_data = procpool.starmap(
             compute_lists_proc,
-            zip(source_tree.rglob('*'), repeat(source_tree), repeat(search_regex)))
+            zip(filter(lambda x: '.git' not in x.parts, source_tree.rglob('*')), repeat(source_tree), repeat(search_regex)))
 
     # Handle the returned data
     for (used_pep_set, used_pip_set, used_dep_set, used_dip_set, returned_pruning_set,

--- a/devutils/update_lists.py
+++ b/devutils/update_lists.py
@@ -298,7 +298,9 @@ def compute_lists(source_tree, search_regex, processes):
     with Pool(processes) as procpool:
         returned_data = procpool.starmap(
             compute_lists_proc,
-            zip(filter(lambda x: '.git' not in x.parts, source_tree.rglob('*')), repeat(source_tree), repeat(search_regex)))
+            zip(
+                filter(lambda x: '.git' not in x.parts, source_tree.rglob('*')),
+                repeat(source_tree), repeat(search_regex)))
 
     # Handle the returned data
     for (used_pep_set, used_pip_set, used_dep_set, used_dip_set, returned_pruning_set,


### PR DESCRIPTION
for #1389
this change updates `update_lists.py`, `compute_lists` function, to avoid scanning `.git` dirs, so that the script would work for local chromium repo cloned using `git` and `gclient` tools

tested on ubuntu 18 LTS, it's working