### PR TITLE
automatically create empty release for each tag; fixes #1414

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -10,9 +10,6 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@master
-        
       - name: Create Release
         id: create_release
         uses: actions/create-release@latest

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,25 @@
+name: Create new empty release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+        
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
This Github workflow creates a new empty release for each (new) pushed tag and for tags only. Normal push events are getting ignored.

This solution will not create releases for past tags, only for newly pushed ones after this workflow is active.

This is an attempt to fulfill all 3 criteria given by @Eloston in https://github.com/Eloston/ungoogled-chromium/issues/1414#issuecomment-798822753