### PR TITLE
Keeping history saved for longer than 3 months

### DIFF
--- a/patches/extra/ungoogled-chromium/add-flag-to-disable-local-history-expiration.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-disable-local-history-expiration.patch
@@ -1,0 +1,33 @@
+# Keep local history langer than 90 days
+
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -60,4 +60,8 @@
+      "Popups to tabs",
+      "Makes popups open in new tabs.  ungoogled-chromium flag",
+      kOsAll, SINGLE_VALUE_TYPE("popups-to-tabs")},
++    {"keep-old-history",
++     "Keep old history",
++     "Keep history older than 3 months.  ungoogled-chromium flag",
++     kOsAll, SINGLE_VALUE_TYPE("keep-old-history")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
+--- a/components/history/core/browser/history_backend.cc
++++ b/components/history/core/browser/history_backend.cc
+@@ -14,6 +14,7 @@
+ #include <vector>
+
+ #include "base/bind.h"
++#include "base/command_line.h"
+ #include "base/callback_helpers.h"
+ #include "base/compiler_specific.h"
+ #include "base/containers/flat_set.h"
+@@ -871,7 +872,8 @@ void HistoryBackend::InitImpl(
+   db_->GetStartDate(&first_recorded_time_);
+ 
+   // Start expiring old stuff.
+-  expirer_.StartExpiringOldStuff(TimeDelta::FromDays(kExpireDaysThreshold));
++  if (!base::CommandLine::ForCurrentProcess()->HasSwitch("keep-old-kistory"))
++    expirer_.StartExpiringOldStuff(TimeDelta::FromDays(kExpireDaysThreshold));
+
+ #if defined(OS_ANDROID)
+   if (backend_client_) {

--- a/patches/series
+++ b/patches/series
@@ -83,6 +83,7 @@ extra/ungoogled-chromium/disable-dial-repeating-discovery.patch
 extra/ungoogled-chromium/remove-uneeded-ui.patch
 extra/ungoogled-chromium/add-flag-to-close-window-with-last-tab.patch
 extra/ungoogled-chromium/add-flag-to-convert-popups-to-tabs.patch
+extra/ungoogled-chromium/add-flag-to-disable-local-history-expiration.patch
 extra/ungoogled-chromium/add-extra-channel-info.patch
 extra/ungoogled-chromium/prepopulated-search-engines.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch


### PR DESCRIPTION
For a long time, Chrome didn't support to save browser history locally more than 90 days, they ignore the issue and just tell you to sign into google account and sync all your browser history to cloud.
https://bugs.chromium.org/p/chromium/issues/detail?id=500239
People even made up specific extensions to workaround the limit.
https://chrome.google.com/webstore/detail/history-trends-unlimited/pnmchffiealhkdloeffcdnbgdnedheme
