### PR TITLE
Docs+Patches: Add documentation for keep-old-history and fix typo

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -19,6 +19,7 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--fingerprinting-canvas-measuretext-noise` | (Added flag to Bromite feature) Scale the output values of Canvas::measureText() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization.
   `--fingerprinting-client-rects-noise` | (Added flag to Bromite feature) Implements fingerprinting deception of JS APIs `getClientRects()` and `getBoundingClientRect()` by scaling their output values with a random factor in the range -0.0003% to 0.0003%, which are recomputed for every document instantiation.
   `--hide-crashed-bubble` | Hides the bubble box with the message "Restore Pages? Chromium didn't shut down correctly." that shows on startup after the browser did not exit cleanly.
+  `--keep-old-history` | Disables deletion of local browser history after 90 days
   `--max-connections-per-host` | (from Bromite) Configure the maximum allowed connections per host. Valid values are `6` and `15`
   `--omnibox-autocomplete-filtering` | Restrict omnibox autocomplete results to a combination of search suggestions (if enabled), bookmarks, and internal chrome pages.  Accepts `search`, `search-bookmarks`, `search-chrome`, and `search-bookmarks-chrome`.
   `--popups-to-tabs` | Makes popups open in new tabs.

--- a/patches/extra/ungoogled-chromium/add-flag-to-disable-local-history-expiration.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-disable-local-history-expiration.patch
@@ -26,7 +26,7 @@
  
    // Start expiring old stuff.
 -  expirer_.StartExpiringOldStuff(TimeDelta::FromDays(kExpireDaysThreshold));
-+  if (!base::CommandLine::ForCurrentProcess()->HasSwitch("keep-old-kistory"))
++  if (!base::CommandLine::ForCurrentProcess()->HasSwitch("keep-old-history"))
 +    expirer_.StartExpiringOldStuff(TimeDelta::FromDays(kExpireDaysThreshold));
  
  #if defined(OS_ANDROID)

--- a/patches/extra/ungoogled-chromium/add-flag-to-disable-local-history-expiration.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-disable-local-history-expiration.patch
@@ -1,4 +1,4 @@
-# Keep local history langer than 90 days
+# Keep local history longer than 90 days
 
 --- a/chrome/browser/ungoogled_flag_entries.h
 +++ b/chrome/browser/ungoogled_flag_entries.h


### PR DESCRIPTION
I noticed the lack of documentation for the recently added "keep-old-history" flag.

Aditionally, both the commit introducing the flag (#1467) as well as a more recent refresh of the patch
included a typo in the flag check, making it unable to be toggled by `chrome://flags`
