### PR TITLE
Flatpak related issues should be made in the package's repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugreport.md
+++ b/.github/ISSUE_TEMPLATE/bugreport.md
@@ -6,8 +6,10 @@ labels: ''
 assignees: ''
 
 ---
-
-Is your issue related to the ungoogled-chromium flatpak _ONLY_? If so, please direct it to https://github.com/flathub/com.github.Eloston.UngoogledChromium/issues/new. Otherwise delete this line.
+<!-----
+Is your issue related to the ungoogled-chromium flatpak ONLY? If so, please direct it to
+https://github.com/flathub/com.github.Eloston.UngoogledChromium/issues/new instead!
+------>
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/bugreport.md
+++ b/.github/ISSUE_TEMPLATE/bugreport.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+Is your issue related to the ungoogled-chromium flatpak _ONLY_? If so, please direct it to https://github.com/flathub/com.github.Eloston.UngoogledChromium/issues/new. Otherwise delete this line.
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Also, ungoogled-chromium is available in several **software repositories**:
 
 If your GNU/Linux distribution is not listed, there are distro-independent builds available via the following **package managers**:
 
-* Flatpak: Available [in the Flathub repo](https://flathub.org/apps/details/com.github.Eloston.UngoogledChromium) as `com.github.Eloston.UngoogledChromium`
+* Flatpak: Available [in the Flathub repo](https://flathub.org/apps/details/com.github.Eloston.UngoogledChromium) as `com.github.Eloston.UngoogledChromium`. Flatpak related issues should be created in [flathub/com.github.Eloston.UngoogledChromium](https://github.com/flathub/com.github.Eloston.UngoogledChromium)
 * GNU Guix: Available as `ungoogled-chromium`
 * NixOS/nixpkgs: Available as `ungoogled-chromium`
 


### PR DESCRIPTION
People are making flatpak related issues in https://github.com/Eloston/ungoogled-chromium rather than the package's repository. 

This PR directs them to make the issues in package's repository so I could be aware of the issues and let them know when its fixed.