### PR TITLE
Official portable executable

### DIFF
--- a/.github/workflows/scheduled-portable.yml
+++ b/.github/workflows/scheduled-portable.yml
@@ -1,0 +1,74 @@
+name: Create portable executable
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '40 3,15 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Guix cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/guix
+          key: guix-cache-${{ github.sha }}
+          restore-keys: |
+            guix-cache-
+      - name: Install Guix
+        uses: PromyLOPH/guix-install-action@v1
+      - name: Assert that substitute is available
+        run: guix weather ungoogled-chromium
+      - name: Download substitutes
+        run: guix build --no-grafts --fallback ungoogled-chromium
+      - name: Install Recutils
+        run: sudo apt-get -q install recutils
+      - name: Export Guix version
+        run: >
+          echo version=$(guix show ungoogled-chromium | recsel -P version)
+          >> $GITHUB_ENV
+      - name: Create Guix pack
+        run: >
+          guix pack --fallback -RR -S /bin=bin
+          --root=ungoogled-chromium-${{ env.version }}.tar.gz
+          ungoogled-chromium
+      - name: Export Guix commit
+        run: >
+          echo shortcommit=$(echo ${{ env.version }} | cut -d- -f2 | cut -d. -f2)
+          >> $GITHUB_ENV
+      - name: Export long commit
+        run: echo commit=$(git rev-parse ${{ env.shortcommit }}) >> $GITHUB_ENV
+      - name: Create release notes
+        run: |
+          echo "Chromium version: $(echo ${{ env.version }} | cut -d- -f1)" >> release_notes.md
+          echo "Ungoogled revision: $(echo ${{ env.commit }})" >> release_notes.md
+          echo >> release_notes.md
+          echo "Built with GNU Guix on commit " >> release_notes.md
+          echo "$(guix --version | head -n 1 | awk '{ print $NF }')." >> release_notes.md
+          echo >> release_notes.md
+      - name: Update tag
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: latest-portable
+          commit_sha: ${{ env.commit }}
+          message: Latest portable build (${{ env.version }})
+          force_push_tag: true
+      - name: Upload release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: ungoogled-chromium-${{ env.version }}.tar.gz
+          artifactContentType: application/gzip
+          bodyFile: release_notes.md
+          omitBodyDuringUpdate: false
+          omitName: true
+          omitNameDuringUpdate: true
+          tag: latest-portable
+          commit: "${{ env.commit }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ Other platforms are discussed and tracked in this repository's Issue Tracker. Le
 
 ## Downloads
 
-[**Download binaries from here**](//ungoogled-software.github.io/ungoogled-chromium-binaries/)
+An automated, reproducible, and dependency-free build of ungoogled-chromium for 64-bit Linux is available on the [releases page](//github.com/Eloston/ungoogled-chromium/releases).  It can be unpacked anywhere on the file system and invoked with `./bin/chromium` from the directory it was unpacked to.  It is updated daily using [GNU Guix](https://guix.gnu.org) and a custom [GitHub action](/.github/workflows/portable-build.yml).
+
+For other operating systems, **contributor binaries** can be [downloaded from here](//ungoogled-software.github.io/ungoogled-chromium-binaries/).
 
 *NOTE: These binaries are provided by anyone who are willing to build and submit them. Because these binaries are not necessarily [reproducible](https://reproducible-builds.org/), authenticity cannot be guaranteed; In other words, there is always a non-zero probability that these binaries may have been tampered with. In the unlikely event that this has happened to you, please [report it in a new issue](#contributing-reporting-contacting).*
-
-These binaries are known as **contributor binaries**.
 
 Also, ungoogled-chromium is available in several **software repositories**:
 


### PR DESCRIPTION
Hi!

This adds a scheduled GitHub action that uploads an "official" portable Linux executable using GNU Guix.

It addresses #1532 and others.

Guix has a little-known feature to create relocatable binaries of any of its 17000+ packages with almost zero overhead.  This makes use of that feature such that the tarballs can be unpacked and run from anywhere.

It runs daily in order to get security updates, and aborts if the Guix CI system does not have an available "substitute" (build),  because Guix automatically falls back to building locally which will time out on the GitHub CI.

About the README diff: I actually did not change the third line, but Git is thorougly confused because the two sentences start similarly.