### PR TITLE
Disable FLoC

### DIFF
--- a/patches/core/ungoogled-chromium/disable-floc.patch
+++ b/patches/core/ungoogled-chromium/disable-floc.patch
@@ -1,0 +1,69 @@
+--- a/chrome/browser/federated_learning/floc_id_provider_factory.cc
++++ b/chrome/browser/federated_learning/floc_id_provider_factory.cc
+@@ -48,39 +48,7 @@ FlocIdProviderFactory::~FlocIdProviderFa
+ 
+ KeyedService* FlocIdProviderFactory::BuildServiceInstanceFor(
+     content::BrowserContext* context) const {
+-  Profile* profile = Profile::FromBrowserContext(context);
+-
+-  syncer::SyncService* sync_service =
+-      ProfileSyncServiceFactory::GetForProfile(profile);
+-  if (!sync_service)
+-    return nullptr;
+-
+-  PrivacySandboxSettings* privacy_sandbox_settings =
+-      PrivacySandboxSettingsFactory::GetForProfile(profile);
+-  if (!privacy_sandbox_settings)
+-    return nullptr;
+-
+-  FlocRemotePermissionService* floc_remote_permission_service =
+-      FlocRemotePermissionServiceFactory::GetForProfile(profile);
+-  if (!floc_remote_permission_service)
+-    return nullptr;
+-
+-  history::HistoryService* history_service =
+-      HistoryServiceFactory::GetForProfile(profile,
+-                                           ServiceAccessType::IMPLICIT_ACCESS);
+-  if (!history_service)
+-    return nullptr;
+-
+-  syncer::UserEventService* user_event_service =
+-      browser_sync::UserEventServiceFactory::GetForProfile(profile);
+-  if (!user_event_service)
+-    return nullptr;
+-
+-  auto floc_event_logger = std::make_unique<FlocEventLogger>(
+-      sync_service, floc_remote_permission_service, user_event_service);
+-
+-  return new FlocIdProviderImpl(profile->GetPrefs(), privacy_sandbox_settings,
+-                                history_service, std::move(floc_event_logger));
++  return nullptr;
+ }
+ 
+ }  // namespace federated_learning
+--- a/chrome/browser/privacy_sandbox/privacy_sandbox_settings.cc
++++ b/chrome/browser/privacy_sandbox/privacy_sandbox_settings.cc
+@@ -174,11 +174,7 @@ PrivacySandboxSettings::~PrivacySandboxS
+ bool PrivacySandboxSettings::IsFlocAllowed(
+     const GURL& url,
+     const base::Optional<url::Origin>& top_frame_origin) const {
+-  ContentSettingsForOneType cookie_settings;
+-  cookie_settings_->GetCookieSettings(&cookie_settings);
+-
+-  return IsPrivacySandboxAllowedForContext(url, top_frame_origin,
+-                                           cookie_settings);
++  return false;
+ }
+ 
+ base::Time PrivacySandboxSettings::FlocDataAccessibleSince() const {
+--- a/components/federated_learning/features/features.cc
++++ b/components/federated_learning/features/features.cc
+@@ -28,7 +28,7 @@ const base::Feature kFlocPagesWithAdReso
+ // required.
+ // TODO(yaoxia): merge other floc features into this one.
+ const base::Feature kFederatedLearningOfCohorts{
+-    "FederatedLearningOfCohorts", base::FEATURE_ENABLED_BY_DEFAULT};
++    "FederatedLearningOfCohorts", base::FEATURE_DISABLED_BY_DEFAULT};
+ constexpr base::FeatureParam<base::TimeDelta> kFlocIdScheduledUpdateInterval{
+     &kFederatedLearningOfCohorts, "update_interval",
+     base::TimeDelta::FromDays(7)};

--- a/patches/series
+++ b/patches/series
@@ -33,6 +33,7 @@ core/ungoogled-chromium/fix-building-without-safebrowsing.patch
 core/ungoogled-chromium/remove-unused-preferences-fields.patch
 core/ungoogled-chromium/fix-building-without-enabling-reporting.patch
 core/ungoogled-chromium/block-requests.patch
+core/ungoogled-chromium/disable-floc.patch
 core/bromite/disable-fetching-field-trials.patch
 core/chromium-upstream/fix-crash-in-ThemeService.patch
 


### PR DESCRIPTION
This PR disables Federated Learning of Cohorts (FLoC) functionality.  Currently FLoC is enabled through an origin trial and is expected to be implemented next month.  

The change in `floc_id_provider_factory.cc` is the most significant at this point.  
The other two changes aren't used extensively yet but will matter more in the future as FLoC is updated.  There are already new commits on the main branch that make further use of `IsFlocAllowed()` and most of the checks on `kInterestCohortAPIOriginTrial` will likely be updated to check `kFederatedLearningOfCohorts`.  

Resolves #1474 