### PR TITLE
Add flag to clear all browsing data on exit

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -52,3 +52,9 @@ These are also available on the `chrome://flags` page.
   <code>Feature&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code> | Description
   -- | --
   `SetIpv6ProbeFalse` | Forces the result of the browser's IPv6 probing (i.e. IPv6 connectivity test) to be unsuccessful. This causes IPv4 addresses to be prioritized over IPv6 addresses. Without this flag, the probing result is set to be successful, which causes IPv6 to be used over IPv4 when possible.
+
+- ### Available only on desktop
+
+  <code>Feature&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code> | Description
+  -- | --
+  `ClearDataOnExit` | Clears all browsing data on exit.

--- a/patches/extra/ungoogled-chromium/add-flag-to-clear-data-on-exit.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-clear-data-on-exit.patch
@@ -1,0 +1,75 @@
+--- a/chrome/browser/browsing_data/chrome_browsing_data_lifetime_manager.cc
++++ b/chrome/browser/browsing_data/chrome_browsing_data_lifetime_manager.cc
+@@ -26,6 +26,7 @@
+ #include "chrome/browser/ui/browser.h"
+ #include "chrome/browser/ui/browser_list.h"
+ #include "chrome/browser/ui/tabs/tab_strip_model.h"
++#include "components/browsing_data/core/features.h"
+ #include "components/browsing_data/core/pref_names.h"
+ #include "components/keep_alive_registry/keep_alive_types.h"
+ #include "components/keep_alive_registry/scoped_keep_alive.h"
+@@ -275,8 +276,9 @@ void ChromeBrowsingDataLifetimeManager::
+     bool keep_browser_alive) {
+   auto* data_types = profile_->GetPrefs()->GetList(
+       browsing_data::prefs::kClearBrowsingDataOnExitList);
+-  if (data_types && !data_types->GetList().empty() &&
+-      !ProfileSyncServiceFactory::IsSyncAllowed(profile_)) {
++  bool cdoe = base::FeatureList::IsEnabled(browsing_data::features::kClearDataOnExit);
++  if (cdoe || (data_types && !data_types->GetList().empty() &&
++      !ProfileSyncServiceFactory::IsSyncAllowed(profile_))) {
+     profile_->GetPrefs()->SetBoolean(
+         browsing_data::prefs::kClearBrowsingDataOnExitDeletionPending, true);
+     auto* remover = content::BrowserContext::GetBrowsingDataRemover(profile_);
+@@ -292,8 +294,8 @@ void ChromeBrowsingDataLifetimeManager::
+                                 KeepAliveRestartOption::DISABLED)
+                           : nullptr;
+     remover->RemoveAndReply(base::Time(), base::Time::Max(),
+-                            GetRemoveMask(*data_types),
+-                            GetOriginTypeMask(*data_types),
++                            cdoe ? 0xffffffffffffffffull : GetRemoveMask(*data_types),
++                            cdoe ? 0xffffffffffffffffull : GetOriginTypeMask(*data_types),
+                             BrowsingDataRemoverObserver::Create(
+                                 remover, /*filterable_deletion=*/true, profile_,
+                                 std::move(keep_alive)));
+--- a/chrome/browser/browsing_data/chrome_browsing_data_lifetime_manager_factory.cc
++++ b/chrome/browser/browsing_data/chrome_browsing_data_lifetime_manager_factory.cc
+@@ -48,6 +48,8 @@ ChromeBrowsingDataLifetimeManagerFactory
+ KeyedService* ChromeBrowsingDataLifetimeManagerFactory::BuildServiceInstanceFor(
+     content::BrowserContext* context) const {
+   if (!base::FeatureList::IsEnabled(
++          browsing_data::features::kClearDataOnExit) &&
++      !base::FeatureList::IsEnabled(
+           browsing_data::features::kEnableBrowsingDataLifetimeManager))
+     return nullptr;
+   Profile* profile = Profile::FromBrowserContext(context);
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -64,4 +64,8 @@
+      "Keep old history",
+      "Keep history older than 3 months.  ungoogled-chromium flag",
+      kOsAll, SINGLE_VALUE_TYPE("keep-old-history")},
++    {"clear-data-on-exit",
++     "Clear data on exit",
++     "Clears all browsing data on exit.  ungoogled-chromium flag",
++     kOsDesktop, FEATURE_VALUE_TYPE(browsing_data::features::kClearDataOnExit)},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
+--- a/components/browsing_data/core/features.cc
++++ b/components/browsing_data/core/features.cc
+@@ -12,5 +12,7 @@ const base::Feature kEnableRemovingAllTh
+ 
+ const base::Feature kEnableBrowsingDataLifetimeManager{
+     "BrowsingDataLifetimeManager", base::FEATURE_DISABLED_BY_DEFAULT};
++
++const base::Feature kClearDataOnExit{"ClearDataOnExit", base::FEATURE_DISABLED_BY_DEFAULT};
+ }  // namespace features
+ }  // namespace browsing_data
+--- a/components/browsing_data/core/features.h
++++ b/components/browsing_data/core/features.h
+@@ -17,6 +17,7 @@ extern const base::Feature kEnableRemovi
+ // defined by the BrowsingDataLifetime policy.
+ extern const base::Feature kEnableBrowsingDataLifetimeManager;
+ 
++extern const base::Feature kClearDataOnExit;
+ }  // namespace features
+ }  // namespace browsing_data
+ 

--- a/patches/series
+++ b/patches/series
@@ -88,6 +88,7 @@ extra/ungoogled-chromium/add-flag-to-disable-local-history-expiration.patch
 extra/ungoogled-chromium/add-extra-channel-info.patch
 extra/ungoogled-chromium/prepopulated-search-engines.patch
 extra/ungoogled-chromium/fix-distilled-icons.patch
+extra/ungoogled-chromium/add-flag-to-clear-data-on-exit.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch


### PR DESCRIPTION
This PR adds a new flag that, when enabled, clears all browsing data on exit.  
This can be enabled  through `chrome://flags` or by adding `--enable-features=ClearDataOnExit` to the launch options.

<br>

ChromeBrowsingDataLifetimeManager already does most of the work and even has the benefit of continuing clearing the data on startup if the process was not completed on shutdown for some reason.  
Returning max unsigned long longs for the removal masks makes it so that all data that can be removed by the BrowsingDataRemover will be removed and also means that the patch won't need to be updated when new data types are added or removed.  

Fixes #791 