### PR TITLE
Add flags for tabsearch, QR generator, and grab handle

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -31,6 +31,7 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--bookmark-bar-ntp` | Sets the visibility of the bookmark bar on the New Tab Page. Only takes the value `never`.
   `--close-window-with-last-tab` | Determines whether a window should close once the last tab is closed.  Only takes the value `never`.
   `--pdf-plugin-name` | Sets the internal PDF viewer plugin name. Useful for sites that probe JavaScript API `navigator.plugins`. Supports values `chrome` for Chrome, `edge` for Microsoft Edge. Default value when omitted is Chromium.
+  `--remove-tabsearch-button` | Removes the tabsearch button from the tabstrip.
   `--scroll-tabs` | Determines if scrolling will cause a switch to a neighboring tab if the cursor hovers over the tabs, or the empty space beside the tabs. The flag requires one the values: `always`, `never`, `incognito-and-guest`. When omitted, the default is to use platform-specific behavior, which is currently enabled only on desktop Linux.
   `--show-avatar-button` | Sets visibility of the avatar button. The flag requires one of the values: `always`, `incognito-and-guest` (only show Incognito or Guest modes), or `never`.
 

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -31,6 +31,7 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--bookmark-bar-ntp` | Sets the visibility of the bookmark bar on the New Tab Page. Only takes the value `never`.
   `--close-window-with-last-tab` | Determines whether a window should close once the last tab is closed.  Only takes the value `never`.
   `--pdf-plugin-name` | Sets the internal PDF viewer plugin name. Useful for sites that probe JavaScript API `navigator.plugins`. Supports values `chrome` for Chrome, `edge` for Microsoft Edge. Default value when omitted is Chromium.
+  `--remove-grab-handle` | Removes the reserved empty space in the tabstrip for moving the window.
   `--remove-tabsearch-button` | Removes the tabsearch button from the tabstrip.
   `--scroll-tabs` | Determines if scrolling will cause a switch to a neighboring tab if the cursor hovers over the tabs, or the empty space beside the tabs. The flag requires one the values: `always`, `never`, `incognito-and-guest`. When omitted, the default is to use platform-specific behavior, which is currently enabled only on desktop Linux.
   `--show-avatar-button` | Sets visibility of the avatar button. The flag requires one of the values: `always`, `incognito-and-guest` (only show Incognito or Guest modes), or `never`.

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -59,3 +59,4 @@ These are also available on the `chrome://flags` page.
   <code>Feature&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code> | Description
   -- | --
   `ClearDataOnExit` | Clears all browsing data on exit.
+  `DisableQRGenerator` | Disables the QR generator for sharing page links.

--- a/patches/extra/ungoogled-chromium/add-flag-for-grab-handle.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-grab-handle.patch
@@ -1,0 +1,21 @@
+--- a/chrome/browser/ui/views/frame/tab_strip_region_view.cc
++++ b/chrome/browser/ui/views/frame/tab_strip_region_view.cc
+@@ -72,6 +72,7 @@ class FrameGrabHandle : public views::Vi
+     // Reserve some space for the frame to be grabbed by, even if the tabstrip
+     // is full.
+     // TODO(tbergquist): Define this relative to the NTB insets again.
++    if (base::CommandLine::ForCurrentProcess()->HasSwitch("remove-grab-handle")) return gfx::Size(0, 0);
+     return gfx::Size(42, 0);
+   }
+ };
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -76,4 +76,8 @@
+      "Disable QR Generator",
+      "Disables the QR generator for sharing page links.  ungoogled-chromium flag",
+      kOsDesktop, FEATURE_VALUE_TYPE(kDisableQRGenerator)},
++    {"remove-grab-handle",
++     "Remove Grab Handle",
++     "Removes the reserved empty space in the tabstrip for moving the window.  ungoogled-chromium flag",
++     kOsDesktop, SINGLE_VALUE_TYPE("remove-grab-handle")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-for-qr-generator.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-qr-generator.patch
@@ -1,0 +1,50 @@
+--- a/chrome/browser/sharing/features.cc
++++ b/chrome/browser/sharing/features.cc
+@@ -50,3 +50,5 @@ const base::Feature kSharingPreferVapid
+       base::FEATURE_DISABLED_BY_DEFAULT
+ #endif  // defined(OS_ANDROID)
+ };
++
++const base::Feature kDisableQRGenerator{"DisableQRGenerator", base::FEATURE_DISABLED_BY_DEFAULT};
+--- a/chrome/browser/sharing/features.h
++++ b/chrome/browser/sharing/features.h
+@@ -54,4 +54,5 @@ extern const base::Feature kSharingSendV
+ // Feature flag for prefer sending sharing message using VAPID.
+ extern const base::Feature kSharingPreferVapid;
+ 
++extern const base::Feature kDisableQRGenerator;
+ #endif  // CHROME_BROWSER_SHARING_FEATURES_H_
+--- a/chrome/browser/ui/qrcode_generator/qrcode_generator_bubble_controller.cc
++++ b/chrome/browser/ui/qrcode_generator/qrcode_generator_bubble_controller.cc
+@@ -22,7 +22,7 @@ QRCodeGeneratorBubbleController::~QRCode
+ 
+ // static
+ bool QRCodeGeneratorBubbleController::IsGeneratorAvailable(const GURL& url) {
+-  if (!url.SchemeIsHTTPOrHTTPS())
++  if (!url.SchemeIsHTTPOrHTTPS() || base::FeatureList::IsEnabled(kDisableQRGenerator))
+     return false;
+ 
+   return true;
+--- a/chrome/browser/ui/views/location_bar/location_bar_view.cc
++++ b/chrome/browser/ui/views/location_bar/location_bar_view.cc
+@@ -265,7 +265,8 @@ void LocationBarView::Init() {
+     // the left most icon.
+     params.types_enabled.push_back(PageActionIconType::kSendTabToSelf);
+     params.types_enabled.push_back(PageActionIconType::kClickToCall);
+-    params.types_enabled.push_back(PageActionIconType::kQRCodeGenerator);
++    if (!base::FeatureList::IsEnabled(kDisableQRGenerator))
++      params.types_enabled.push_back(PageActionIconType::kQRCodeGenerator);
+     if (base::FeatureList::IsEnabled(kSharedClipboardUI))
+       params.types_enabled.push_back(PageActionIconType::kSharedClipboard);
+     if (base::FeatureList::IsEnabled(kWebOTPCrossDevice))
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -72,4 +72,8 @@
+      "Remove Tabsearch Button",
+      "Removes the tabsearch button from the tabstrip.  ungoogled-chromium flag",
+      kOsDesktop, SINGLE_VALUE_TYPE("remove-tabsearch-button")},
++    {"disable-qr-generator",
++     "Disable QR Generator",
++     "Disables the QR generator for sharing page links.  ungoogled-chromium flag",
++     kOsDesktop, FEATURE_VALUE_TYPE(kDisableQRGenerator)},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-for-tabsearch-button.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-tabsearch-button.patch
@@ -1,0 +1,43 @@
+--- a/chrome/browser/ui/browser_command_controller.cc
++++ b/chrome/browser/ui/browser_command_controller.cc
+@@ -1110,7 +1110,8 @@ void BrowserCommandController::InitComma
+   command_updater_.UpdateCommandEnabled(IDC_WINDOW_CLOSE_OTHER_TABS,
+                                         normal_window);
+ 
+-  const bool enable_tab_search_commands = browser_->is_type_normal();
++  const bool enable_tab_search_commands = browser_->is_type_normal() &&
++      !base::CommandLine::ForCurrentProcess()->HasSwitch("remove-tabsearch-button");
+   command_updater_.UpdateCommandEnabled(IDC_TAB_SEARCH,
+                                         enable_tab_search_commands);
+   command_updater_.UpdateCommandEnabled(IDC_TAB_SEARCH_CLOSE,
+--- a/chrome/browser/ui/views/frame/tab_strip_region_view.cc
++++ b/chrome/browser/ui/views/frame/tab_strip_region_view.cc
+@@ -5,6 +5,7 @@
+ #include "chrome/browser/ui/views/frame/tab_strip_region_view.h"
+ 
+ #include "base/bind.h"
++#include "base/command_line.h"
+ #include "base/strings/utf_string_conversions.h"
+ #include "chrome/app/vector_icons/vector_icons.h"
+ #include "chrome/browser/ui/layout_constants.h"
+@@ -260,7 +261,8 @@ TabStripRegionView::TabStripRegionView(s
+   tip_marquee_view_->SetProperty(views::kMarginsKey, control_padding);
+ 
+   const Browser* browser = tab_strip_->controller()->GetBrowser();
+-  if (browser && browser->is_type_normal()) {
++  if (browser && browser->is_type_normal() &&
++      !base::CommandLine::ForCurrentProcess()->HasSwitch("remove-tabsearch-button")) {
+     auto tab_search_button = std::make_unique<TabSearchButton>(tab_strip_);
+     tab_search_button->SetTooltipText(
+         l10n_util::GetStringUTF16(IDS_TOOLTIP_TAB_SEARCH));
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -68,4 +68,8 @@
+      "Clear data on exit",
+      "Clears all browsing data on exit.  ungoogled-chromium flag",
+      kOsDesktop, FEATURE_VALUE_TYPE(browsing_data::features::kClearDataOnExit)},
++    {"remove-tabsearch-button",
++     "Remove Tabsearch Button",
++     "Removes the tabsearch button from the tabstrip.  ungoogled-chromium flag",
++     kOsDesktop, SINGLE_VALUE_TYPE("remove-tabsearch-button")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/series
+++ b/patches/series
@@ -89,6 +89,7 @@ extra/ungoogled-chromium/add-extra-channel-info.patch
 extra/ungoogled-chromium/prepopulated-search-engines.patch
 extra/ungoogled-chromium/fix-distilled-icons.patch
 extra/ungoogled-chromium/add-flag-to-clear-data-on-exit.patch
+extra/ungoogled-chromium/add-flag-for-tabsearch-button.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch

--- a/patches/series
+++ b/patches/series
@@ -90,6 +90,7 @@ extra/ungoogled-chromium/prepopulated-search-engines.patch
 extra/ungoogled-chromium/fix-distilled-icons.patch
 extra/ungoogled-chromium/add-flag-to-clear-data-on-exit.patch
 extra/ungoogled-chromium/add-flag-for-tabsearch-button.patch
+extra/ungoogled-chromium/add-flag-for-qr-generator.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch

--- a/patches/series
+++ b/patches/series
@@ -91,6 +91,7 @@ extra/ungoogled-chromium/fix-distilled-icons.patch
 extra/ungoogled-chromium/add-flag-to-clear-data-on-exit.patch
 extra/ungoogled-chromium/add-flag-for-tabsearch-button.patch
 extra/ungoogled-chromium/add-flag-for-qr-generator.patch
+extra/ungoogled-chromium/add-flag-for-grab-handle.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch


### PR DESCRIPTION
This PR contains two commits, the first adds a flag that removes the tabsearch button (and it's keyboard shortcut), the second adds a flag to disable the QR generator for sharing page links.  

Fixes #1553 and #1574 