### PR TITLE
Add Windows compatibility for prune_binaries.py

### DIFF
--- a/utils/prune_binaries.py
+++ b/utils/prune_binaries.py
@@ -10,7 +10,9 @@ import argparse
 from pathlib import Path
 
 from _common import ENCODING, get_logger, add_common_params
-import sys, os, stat
+import sys
+import os
+import stat
 
 
 def prune_dir(unpack_root, prune_files):
@@ -25,6 +27,8 @@ def prune_dir(unpack_root, prune_files):
         file_path = unpack_root / relative_file
         try:
             file_path.unlink()
+        # read-only files can't be deleted on Windows
+        # so remove the flag and try again.
         except PermissionError:
             os.chmod(file_path, stat.S_IWRITE)
             file_path.unlink()

--- a/utils/prune_binaries.py
+++ b/utils/prune_binaries.py
@@ -10,7 +10,7 @@ import argparse
 from pathlib import Path
 
 from _common import ENCODING, get_logger, add_common_params
-import sys
+import sys, os, stat
 
 
 def prune_dir(unpack_root, prune_files):
@@ -24,6 +24,9 @@ def prune_dir(unpack_root, prune_files):
     for relative_file in prune_files:
         file_path = unpack_root / relative_file
         try:
+            file_path.unlink()
+        except PermissionError:
+            os.chmod(file_path, stat.S_IWRITE)
             file_path.unlink()
         except FileNotFoundError:
             unremovable_files.add(Path(relative_file).as_posix())


### PR DESCRIPTION
`file_path.unlink()` is not able to remove read-only files on Windows.
