### PR TITLE
Updates to `remove-uneeded-ui.patch`

### DIFF
--- a/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
+++ b/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
@@ -1,14 +1,17 @@
 # Removes in order:
 # 'Tabs from other devices' entry on the History page sidebar
+# the 'Learn more' link on new incognito tabs
+# Live captions entry from the settings page
 # link to Google's accessibility site from the settings page
 # link to Google's help site on the About page
+# external link for theme entry on settings page
+# Check passwords and managed passwords sections from the passwords page
 # Safety check section on the settings page
-# option to offer page translations on the settings page
-# cloud printing entry on the settings page
-# option for password leak detection on the settings page
 # Google sign-in and Anonymized Data Collection sections
 # Advanced Protection Program link on the security settings page
+# the 'Learn more' link from the search engine entry on the settings page
 # Safety Check entry on the side menu on the settings page
+# the (?) learn more button on many settings pages
 # unneeded elements from the profile menu
 
 --- a/chrome/browser/resources/history/side_bar.html
@@ -25,8 +28,28 @@
          <div class="separator"></div>
          <a role="menuitem" id="clear-browsing-data"
              href="chrome://settings/clearBrowserData"
+--- a/chrome/browser/resources/ntp4/incognito_tab.html
++++ b/chrome/browser/resources/ntp4/incognito_tab.html
+@@ -25,8 +25,6 @@ document.querySelector('#incognitothemec
+   <h1>$i18n{incognitoTabHeading}</h1>
+   <p id="subtitle">
+     <span>$i18n{incognitoTabDescription}</span>
+-    <a class="learn-more-button"
+-        href="$i18n{learnMoreLink}">$i18n{learnMore}</a>
+   </p>
+   <div id="bulletpoints-wrapper">
+     <div class="bulletpoints first">$i18nRaw{incognitoTabFeatures}</div>
 --- a/chrome/browser/resources/settings/a11y_page/a11y_page.html
 +++ b/chrome/browser/resources/settings/a11y_page/a11y_page.html
+@@ -21,7 +21,7 @@
+               external$="[[captionSettingsOpensExternally_]]">
+           </cr-link-row>
+         </template>
+-        <template is="dom-if" if="[[!captionSettingsOpensExternally_]]">
++        <template is="dom-if" if="[[false]]">
+           <cr-link-row id="captions"
+               label="$i18n{captionsTitle}"
+               on-click="onCaptionsClick_"
 @@ -51,10 +51,6 @@
              sub-label="$i18n{accessibleImageLabelsSubtitle}">
          </settings-toggle-button>
@@ -49,24 +72,53 @@
  <if expr="_google_chrome">
        <cr-link-row class="hr" id="reportIssue" on-click="onReportIssueTap_"
            hidden="[[!prefs.feedback_allowed.value]]"
+--- a/chrome/browser/resources/settings/appearance_page/appearance_page.html
++++ b/chrome/browser/resources/settings/appearance_page/appearance_page.html
+@@ -22,11 +22,11 @@
+     <settings-animated-pages id="pages" section="appearance"
+         focus-config="[[focusConfig_]]">
+       <div route-path="default">
+-        <div class="settings-row first" id="themeRow"
++        <div class="cr-row first" id="themeRow"
+             hidden="[[!pageVisibility.setTheme]]">
+-          <cr-link-row class="first" hidden="[[!pageVisibility.setTheme]]"
+-              label="$i18n{themes}" sub-label="[[themeSublabel_]]"
+-              on-click="openThemeUrl_" external></cr-link-row>
++          <div class="flex cr-padded-text">
++            <div>$i18n{themes}</div><div class="secondary">[[themeSublabel_]]</div>
++          </div>
+ <if expr="not is_linux or chromeos or lacros">
+           <template is="dom-if" if="[[prefs.extensions.theme.id.value]]">
+             <div class="separator"></div>
+--- a/chrome/browser/resources/settings/autofill_page/passwords_section.html
++++ b/chrome/browser/resources/settings/autofill_page/passwords_section.html
+@@ -106,6 +106,7 @@
+         label="$i18n{trustedVaultOptInLabel}"
+         sub-label="$i18n{trustedVaultOptInSubLabel}">
+     </cr-link-row>
++<if expr="false">
+     <div id="checkPasswordsBannerContainer" class="cr-row"
+         hidden$="[[!shouldShowBanner_]]">
+       <picture>
+@@ -154,6 +155,7 @@
+       <!-- This div lays out the link correctly, relative to the text. -->
+       <div class="cr-padded-text">$i18nRaw{managePasswordsLabel}</div>
+     </div>
++</if>
+     <div class="cr-row first">
+       <h2 id="savedPasswordsHeading" class="flex">
+         $i18n{savedPasswordsHeading}
 --- a/chrome/browser/resources/settings/basic_page/basic_page.html
 +++ b/chrome/browser/resources/settings/basic_page/basic_page.html
-@@ -95,6 +95,7 @@
+@@ -95,7 +95,7 @@
              <settings-autofill-page prefs="{{prefs}}"></settings-autofill-page>
            </settings-section>
          </template>
-+<if expr="false">
-         <template is="dom-if" if="[[showPage_(pageVisibility.safetyCheck)]]"
+-        <template is="dom-if" if="[[showPage_(pageVisibility.safetyCheck)]]"
++        <template is="dom-if" if="[[false]]"
              restamp>
            <settings-section page-title="$i18n{safetyCheckSectionTitle}"
-@@ -104,6 +105,7 @@
-             </settings-safety-check-page>
-           </settings-section>
-         </template>
-+</if>
-         <template is="dom-if" if="[[showPage_(pageVisibility.privacy)]]"
-             restamp>
-           <settings-section page-title="$i18n{privacyPageTitle}"
+               section="safetyCheck" nest-under-section="privacy"
 --- a/chrome/browser/resources/settings/privacy_page/personalization_options.html
 +++ b/chrome/browser/resources/settings/privacy_page/personalization_options.html
 @@ -8,7 +8,7 @@
@@ -104,23 +156,41 @@
 -        on-click="onAdvancedProtectionProgramLinkClick_"
 -        external>
 -    </cr-link-row>
+--- a/chrome/browser/resources/settings/search_page/search_page.html
++++ b/chrome/browser/resources/settings/search_page/search_page.html
+@@ -12,10 +12,6 @@
+     <div class="cr-row first">
+       <div id="searchExplanation" class="flex cr-padded-text">
+         $i18n{searchExplanation}
+-        <a href="$i18n{searchExplanationLearnMoreURL}"
+-            target="_blank">
+-          $i18n{learnMore}
+-        </a>
+       </div>
+       <template is="dom-if" if="[[isDefaultSearchControlledByPolicy_(
+           prefs.default_search_provider_data.template_url_data)]]">
 --- a/chrome/browser/resources/settings/settings_menu/settings_menu.html
 +++ b/chrome/browser/resources/settings/settings_menu/settings_menu.html
-@@ -111,14 +111,6 @@
+@@ -111,7 +111,7 @@
              <iron-icon icon="settings:assignment"></iron-icon>
              $i18n{autofillPageTitle}
            </a>
 -          <template is="dom-if" if="[[!enableLandingPageRedesign_]]">
--            <a role="menuitem" href="/safetyCheck"
--                hidden="[[!pageVisibility.safetyCheck]]"
--                id="safetyCheck">
--              <iron-icon icon="settings20:safety-check"></iron-icon>
--              $i18n{safetyCheckSectionTitle}
--            </a>
--          </template>
-           <a role="menuitem" href="/privacy"
-               hidden="[[!pageVisibility.privacy]]">
-             <iron-icon icon="cr:security"></iron-icon>
++          <template is="dom-if" if="[[false]]">
+             <a role="menuitem" href="/safetyCheck"
+                 hidden="[[!pageVisibility.safetyCheck]]"
+                 id="safetyCheck">
+--- a/chrome/browser/resources/settings/settings_page/settings_subpage.html
++++ b/chrome/browser/resources/settings/settings_page/settings_subpage.html
+@@ -68,7 +68,7 @@
+       </template>
+       <h1 class="cr-title-text">[[pageTitle]]</h1>
+       <slot name="subpage-title-extra"></slot>
+-      <template is="dom-if" if="[[learnMoreUrl]]">
++      <template is="dom-if" if="[[false]]">
+         <cr-icon-button iron-icon="cr:help-outline" dir="ltr"
+             aria-label="$i18n{learnMore}" on-click="onHelpClick_">
+         </cr-icon-button>
 --- a/chrome/browser/ui/views/profiles/profile_menu_view.cc
 +++ b/chrome/browser/ui/views/profiles/profile_menu_view.cc
 @@ -220,6 +220,7 @@ void ProfileMenuView::BuildMenu() {


### PR DESCRIPTION
This PR makes some small changes to `remove-uneeded-ui.patch`:

* Removes the 'Learn more' link on new incognito tabs.
* Removes the live captions entry in the settings.  It's possible that this could be enabled manually somehow, so this change only removes the entry on the settings page.  The caption settings can still be reached at `chrome://settings/captions`.  
* Removes the external link for theme entry on settings page.
* Removes the password check and managed password entries from the password page.
* Removes the (?) learn more buttons from settings pages.
* Removes the 'Larn more' link from the search engines entry on the settings page.
* Updated the safetycheck removals to disable their templates.

Addresses #1597, #1514, and #605