### PR TITLE
Add flag to show a prompt when closing mutitab

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -29,6 +29,7 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   <code>Switch&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code> | Description
   -- | --
   `--bookmark-bar-ntp` | Sets the visibility of the bookmark bar on the New Tab Page. Only takes the value `never`.
+  `--close-multitab-confirmation` | Show a warning prompt when closing multiple tabs.
   `--close-window-with-last-tab` | Determines whether a window should close once the last tab is closed.  Only takes the value `never`.
   `--pdf-plugin-name` | Sets the internal PDF viewer plugin name. Useful for sites that probe JavaScript API `navigator.plugins`. Supports values `chrome` for Chrome, `edge` for Microsoft Edge. Default value when omitted is Chromium.
   `--remove-grab-handle` | Removes the reserved empty space in the tabstrip for moving the window.

--- a/patches/extra/ungoogled-chromium/add-flag-for-close-multitab-confirmation.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-close-multitab-confirmation.patch
@@ -1,0 +1,169 @@
+--- a/chrome/browser/ui/browser.cc
++++ b/chrome/browser/ui/browser.cc
+@@ -140,6 +140,8 @@
+ #include "chrome/browser/ui/tabs/tab_strip_model.h"
+ #include "chrome/browser/ui/tabs/tab_utils.h"
+ #include "chrome/browser/ui/ui_features.h"
++#include "chrome/browser/ui/views/frame/browser_view.h"
++#include "chrome/browser/ui/views/message_box_dialog.h"
+ #include "chrome/browser/ui/web_applications/app_browser_controller.h"
+ #include "chrome/browser/ui/webui/signin/login_ui_service.h"
+ #include "chrome/browser/ui/webui/signin/login_ui_service_factory.h"
+@@ -464,6 +466,7 @@ Browser::Browser(const CreateParams& par
+       omit_from_session_restore_(params.omit_from_session_restore),
+       should_trigger_session_restore_(params.should_trigger_session_restore),
+       cancel_download_confirmation_state_(NOT_PROMPTED),
++      close_multitab_confirmation_state_(NOT_PROMPTED),
+       override_bounds_(params.initial_bounds),
+       initial_show_state_(params.initial_show_state),
+       initial_workspace_(params.initial_workspace),
+@@ -828,7 +831,7 @@ Browser::WarnBeforeClosingResult Browser
+   // If the browser can close right away (there are no pending downloads we need
+   // to prompt about) then there's no need to warn. In the future, we might need
+   // to check other conditions as well.
+-  if (CanCloseWithInProgressDownloads())
++  if (CanCloseWithInProgressDownloads() && CanCloseWithMultipleTabs())
+     return WarnBeforeClosingResult::kOkToClose;
+ 
+   DCHECK(!warn_before_closing_callback_)
+@@ -852,12 +855,14 @@ bool Browser::TryToCloseWindow(
+     bool skip_beforeunload,
+     const base::RepeatingCallback<void(bool)>& on_close_confirmed) {
+   cancel_download_confirmation_state_ = RESPONSE_RECEIVED;
++  close_multitab_confirmation_state_ = RESPONSE_RECEIVED;
+   return unload_controller_.TryToCloseWindow(skip_beforeunload,
+                                              on_close_confirmed);
+ }
+ 
+ void Browser::ResetTryToCloseWindow() {
+   cancel_download_confirmation_state_ = NOT_PROMPTED;
++  close_multitab_confirmation_state_ = NOT_PROMPTED;
+   unload_controller_.ResetTryToCloseWindow();
+ }
+ 
+@@ -2696,6 +2701,54 @@ bool Browser::CanCloseWithInProgressDown
+   return false;
+ }
+ 
++bool Browser::CanCloseWithMultipleTabs() {
++  if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
++          "close-multitab-confirmation"))
++    return true;
++
++  // If we've prompted, we need to hear from the user before we
++  // can close.
++  if (close_multitab_confirmation_state_ != NOT_PROMPTED)
++    return close_multitab_confirmation_state_ != WAITING_FOR_RESPONSE;
++
++  // If we're not running a full browser process with a profile manager
++  // (testing), it's ok to close the browser.
++  if (!g_browser_process->profile_manager())
++    return true;
++
++  // Figure out how many windows are open total
++  int total_window_count = 0;
++  for (auto* browser : *BrowserList::GetInstance()) {
++    // Don't count this browser window or any other in the process of closing.
++    // Window closing may be delayed, and windows that are in the process of
++    // closing don't count against our totals.
++    if (browser == this || browser->IsAttemptingToCloseBrowser())
++      continue;
++    total_window_count++;
++  }
++
++  if (total_window_count >= 1 || this->IsAttemptingToCloseBrowser() ||
++      this->tab_strip_model()->count() <= 1)
++    return true;
++
++  close_multitab_confirmation_state_ = WAITING_FOR_RESPONSE;
++
++  // The dialog eats mouse events which results in the close button
++  // getting stuck in the hover state. Reset the window controls to
++  // prevent this.
++  ((BrowserView*)window_)->frame()->non_client_view()->ResetWindowControls();
++  auto callback = base::BindOnce(&Browser::MultitabResponse,
++                                 weak_factory_.GetWeakPtr());
++  MessageBoxDialog::Show(window_->GetNativeWindow(),
++                         u"Do you want to close all tabs?", std::u16string(),
++                         chrome::MESSAGE_BOX_TYPE_QUESTION, u"Close all",
++                         u"Cancel", std::u16string(), std::move(callback));
++
++  // Return false so the browser does not close.  We'll close if the user
++  // confirms in the dialog.
++  return false;
++}
++
+ void Browser::InProgressDownloadResponse(bool cancel_downloads) {
+   if (cancel_downloads) {
+     cancel_download_confirmation_state_ = RESPONSE_RECEIVED;
+@@ -2714,6 +2767,22 @@ void Browser::InProgressDownloadResponse
+ 
+   std::move(warn_before_closing_callback_)
+       .Run(WarnBeforeClosingResult::kDoNotClose);
++}
++
++void Browser::MultitabResponse(chrome::MessageBoxResult result) {
++  if (result == chrome::MESSAGE_BOX_RESULT_YES) {
++    close_multitab_confirmation_state_ = RESPONSE_RECEIVED;
++    std::move(warn_before_closing_callback_)
++        .Run(WarnBeforeClosingResult::kOkToClose);
++    return;
++  }
++
++  // Sets the confirmation state to NOT_PROMPTED so that if the user tries to
++  // close again we'll show the warning again.
++  close_multitab_confirmation_state_ = NOT_PROMPTED;
++
++  std::move(warn_before_closing_callback_)
++      .Run(WarnBeforeClosingResult::kDoNotClose);
+ }
+ 
+ void Browser::FinishWarnBeforeClosing(WarnBeforeClosingResult result) {
+--- a/chrome/browser/ui/browser.h
++++ b/chrome/browser/ui/browser.h
+@@ -26,6 +26,7 @@
+ #include "chrome/browser/ui/bookmarks/bookmark_tab_helper_observer.h"
+ #include "chrome/browser/ui/browser_navigator_params.h"
+ #include "chrome/browser/ui/chrome_web_modal_dialog_manager_delegate.h"
++#include "chrome/browser/ui/simple_message_box.h"
+ #include "chrome/browser/ui/signin_view_controller.h"
+ #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
+ #include "chrome/browser/ui/unload_controller.h"
+@@ -1005,12 +1006,17 @@ class Browser : public TabStripModelObse
+   // Returns true if the window can close, false otherwise.
+   bool CanCloseWithInProgressDownloads();
+ 
++  // Called when the window is closing to check if more than one tabs are open
++  bool CanCloseWithMultipleTabs();
++
+   // Called when the user has decided whether to proceed or not with the browser
+   // closure.  |cancel_downloads| is true if the downloads should be canceled
+   // and the browser closed, false if the browser should stay open and the
+   // downloads running.
+   void InProgressDownloadResponse(bool cancel_downloads);
+ 
++  void MultitabResponse(chrome::MessageBoxResult result);
++
+   // Called when all warnings have completed when attempting to close the
+   // browser directly (e.g. via hotkey, close button, terminate signal, etc.)
+   // Used as a WarnBeforeClosingCallback by ShouldCloseWindow().
+@@ -1173,6 +1179,8 @@ class Browser : public TabStripModelObse
+   // when the browser is closed with in-progress downloads.
+   CancelDownloadConfirmationState cancel_download_confirmation_state_;
+ 
++  CancelDownloadConfirmationState close_multitab_confirmation_state_;
++
+   /////////////////////////////////////////////////////////////////////////////
+ 
+   // Override values for the bounds of the window and its maximized or minimized
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -80,4 +80,8 @@
+      "Remove Grab Handle",
+      "Removes the reserved empty space in the tabstrip for moving the window.  ungoogled-chromium flag",
+      kOsDesktop, SINGLE_VALUE_TYPE("remove-grab-handle")},
++    {"close-multitab-confirmation", 
++     "Close Multitab Confirmation",
++     "Show a warning prompt when closing multiple tabs.  ungoogled-chromium flag",
++     kOsDesktop, SINGLE_VALUE_TYPE("close-multitab-confirmation")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/series
+++ b/patches/series
@@ -93,6 +93,7 @@ extra/ungoogled-chromium/add-flag-to-clear-data-on-exit.patch
 extra/ungoogled-chromium/add-flag-for-tabsearch-button.patch
 extra/ungoogled-chromium/add-flag-for-qr-generator.patch
 extra/ungoogled-chromium/add-flag-for-grab-handle.patch
+extra/ungoogled-chromium/add-flag-for-close-multitab-confirmation.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch


### PR DESCRIPTION
This PR adds a flag that allows users to confirm whether they want to close the last window when multiple tabs are open in it. 

I sometimes close the browser accidentally and cannot restore the tabs because I have `ClearDataOnExit` enabled. It is exhausting trying to recall what I was browsing. A warning dialog could save the day. :smiley:

Fixes #1665 