### PR TITLE
Add patch to keep expired flags

### DIFF
--- a/patches/extra/ungoogled-chromium/keep-expired-flags.patch
+++ b/patches/extra/ungoogled-chromium/keep-expired-flags.patch
@@ -1,0 +1,38 @@
+--- a/components/flags_ui/flags_state.cc
++++ b/components/flags_ui/flags_state.cc
+@@ -22,6 +22,7 @@
+ #include "base/values.h"
+ #include "build/build_config.h"
+ #include "build/chromeos_buildflags.h"
++#include "chrome/browser/unexpire_flags.h"
+ #include "components/flags_ui/feature_entry.h"
+ #include "components/flags_ui/flags_storage.h"
+ #include "components/flags_ui/flags_ui_switches.h"
+@@ -577,14 +578,18 @@ void FlagsState::GetFlagFeatureEntries(
+   int current_platform = GetCurrentPlatform();
+ 
+   for (const FeatureEntry& entry : feature_entries_) {
++    std::string desc = entry.visible_description;
+     if (skip_feature_entry.Run(entry))
++      if (flags::IsFlagExpired(flags_storage, entry.internal_name))
++        desc.insert(0, "!!! NOTE: THIS FLAG IS EXPIRED AND MAY STOP FUNCTIONING OR BE REMOVED SOON !!! ");
++      else
+       continue;
+ 
+     base::Value data(base::Value::Type::DICTIONARY);
+     data.SetStringKey("internal_name", entry.internal_name);
+     data.SetStringKey("name", base::StringPiece(entry.visible_name));
+     data.SetStringKey("description",
+-                      base::StringPiece(entry.visible_description));
++                      base::StringPiece(desc));
+ 
+     base::Value supported_platforms(base::Value::Type::LIST);
+     AddOsStrings(entry.supported_platforms, &supported_platforms);
+@@ -901,6 +906,7 @@ bool FlagsState::IsSupportedFeature(cons
+     if (!entry.InternalNameMatches(name))
+       continue;
+     if (delegate_ && delegate_->ShouldExcludeFlag(storage, entry))
++      if (!flags::IsFlagExpired(storage, entry.internal_name))
+       continue;
+     return true;
+   }

--- a/patches/series
+++ b/patches/series
@@ -94,6 +94,7 @@ extra/ungoogled-chromium/add-flag-for-tabsearch-button.patch
 extra/ungoogled-chromium/add-flag-for-qr-generator.patch
 extra/ungoogled-chromium/add-flag-for-grab-handle.patch
 extra/ungoogled-chromium/add-flag-for-close-confirmation.patch
+extra/ungoogled-chromium/keep-expired-flags.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch


### PR DESCRIPTION
This PR adds a patch that allows expired flags to remain in `chrome://flags` with an added warning that the flag may be removed in a future version.  

This is something that had been on my mind after commenting on #1656.  The Arch repos include a patch that unexpires the accelerated video decode flag and I've seen other issues in the past about flags disappearing.  The code and the flag itself can sometimes stick around for a long time after being expired.  