### PR TITLE
Add flag for setting a custom new tab page

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -31,6 +31,7 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--bookmark-bar-ntp` | Sets the visibility of the bookmark bar on the New Tab Page. Only takes the value `never`.
   `--close-confirmation` | Show a warning prompt when closing the browser window. Accepts `last` (prompt when closing the last window with several tabs) and `multiple` (prompt only if more than one window is open). 
   `--close-window-with-last-tab` | Determines whether a window should close once the last tab is closed.  Only takes the value `never`.
+  `--custom-ntp` | Allows setting a custom URL for the new tab page.  Value can be internal (e.g. `about:blank`), external (e.g. `example.com`), or local (e.g. `file:///tmp/startpage.html`).  This applies for incognito windows as well when not set to a `chrome://` internal page.
   `--pdf-plugin-name` | Sets the internal PDF viewer plugin name. Useful for sites that probe JavaScript API `navigator.plugins`. Supports values `chrome` for Chrome, `edge` for Microsoft Edge. Default value when omitted is Chromium.
   `--remove-grab-handle` | Removes the reserved empty space in the tabstrip for moving the window.
   `--remove-tabsearch-button` | Removes the tabsearch button from the tabstrip.

--- a/patches/extra/ungoogled-chromium/add-flag-for-custom-ntp.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-custom-ntp.patch
@@ -1,0 +1,41 @@
+--- a/chrome/browser/chrome_content_browser_client.cc
++++ b/chrome/browser/chrome_content_browser_client.cc
+@@ -738,6 +738,9 @@ bool HandleNewTabPageLocationOverride(
+   Profile* profile = Profile::FromBrowserContext(browser_context);
+   std::string ntp_location =
+       profile->GetPrefs()->GetString(prefs::kNewTabPageLocationOverride);
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("custom-ntp"))
++    ntp_location = base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("custom-ntp");
++  if (profile->IsOffTheRecord() && ntp_location.find("chrome://") != std::string::npos) return false;
+   if (ntp_location.empty())
+     return false;
+   url::Component scheme;
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -84,4 +84,8 @@
+      "Close Confirmation",
+      "Show a warning prompt when closing the browser window.  ungoogled-chromium flag",
+      kOsDesktop, MULTI_VALUE_TYPE(kCloseConfirmation)},
++    {"custom-ntp",
++     "Custom New Tab Page",
++     "Allows setting a custom URL for the new tab page.  Value can be internal (e.g. `about:blank`), external (e.g. `example.com`), or local (e.g. `file:///tmp/startpage.html`).  This applies for incognito windows as well when not set to a `chrome://` internal page.  ungoogled-chromium flag",
++     kOsDesktop, ORIGIN_LIST_VALUE_TYPE("custom-ntp", "")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
+--- a/components/flags_ui/flags_state.cc
++++ b/components/flags_ui/flags_state.cc
+@@ -231,6 +231,7 @@ std::string GetCombinedOriginListValue(c
+           command_line_switch);
+   const std::string new_value =
+       flags_storage.GetOriginListFlag(internal_entry_name);
++  if (command_line_switch == "custom-ntp") return existing_value.empty() ? new_value : existing_value;
+   return CombineAndSanitizeOriginLists(existing_value, new_value);
+ }
+ 
+@@ -417,6 +418,7 @@ void FlagsState::SetOriginListFlag(const
+                                    const std::string& value,
+                                    FlagsStorage* flags_storage) {
+   const std::string new_value =
++      internal_name == "custom-ntp" ? value :
+       CombineAndSanitizeOriginLists(std::string(), value);
+   flags_storage->SetOriginListFlag(internal_name, new_value);
+ 

--- a/patches/series
+++ b/patches/series
@@ -93,6 +93,7 @@ extra/ungoogled-chromium/add-flag-for-qr-generator.patch
 extra/ungoogled-chromium/add-flag-for-grab-handle.patch
 extra/ungoogled-chromium/add-flag-for-close-confirmation.patch
 extra/ungoogled-chromium/keep-expired-flags.patch
+extra/ungoogled-chromium/add-flag-for-custom-ntp.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch


### PR DESCRIPTION
This PR adds a flag allowing a custom new tab page to be set.  This is handy for anyone that wants a blank new tab page or wants to use a custom [startpage](https://www.reddit.com/r/startpages) for new tabs.  

The page can be internal (e.g. `about:blank`), external (e.g. `example.com`), or local (e.g. `file:///tmp/startpage.html`).  
This applies in incognito as well except when set to a `chrome://` page since most of them require access to the profile.  In those scenarios the normal incognito tab will be shown.  