### PR TITLE
Fix close confirmation issue

### DIFF
--- a/patches/extra/ungoogled-chromium/add-flag-for-close-confirmation.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-close-confirmation.patch
@@ -70,7 +70,7 @@
 +    if (total_window_count >= 1 || this->tab_strip_model()->count() <= 1)
 +      return true;
 +  } else {
-+    if (total_window_count == 0 && this->tab_strip_model()->count() <= 1)
++    if (total_window_count == 0)
 +      return true;
 +    if (this->tab_strip_model()->count() == 0)
 +      tab_strip_model_delegate_->AddTabAt(GURL(), -1, true);


### PR DESCRIPTION
This PR fixes https://github.com/Eloston/ungoogled-chromium/pull/1670#issuecomment-954682653 where the confirmation dialog is prompted even when the `Close Confirmation` is set to `multiple` and there is only one window open. 