### PR TITLE
Add patches for tab hover cards and close buttons

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -37,6 +37,7 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--remove-tabsearch-button` | Removes the tabsearch button from the tabstrip.
   `--scroll-tabs` | Determines if scrolling will cause a switch to a neighboring tab if the cursor hovers over the tabs, or the empty space beside the tabs. The flag requires one the values: `always`, `never`, `incognito-and-guest`. When omitted, the default is to use platform-specific behavior, which is currently enabled only on desktop Linux.
   `--show-avatar-button` | Sets visibility of the avatar button. The flag requires one of the values: `always`, `incognito-and-guest` (only show Incognito or Guest modes), or `never`.
+  `--tab-hover-cards` | Allows removing the tab hover cards or using a tooltip as a replacement. This can be set with the values `none` or `tooltip`.
 
   - #### Available only on Windows
 

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -32,6 +32,7 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--close-confirmation` | Show a warning prompt when closing the browser window. Accepts `last` (prompt when closing the last window with several tabs) and `multiple` (prompt only if more than one window is open). 
   `--close-window-with-last-tab` | Determines whether a window should close once the last tab is closed.  Only takes the value `never`.
   `--custom-ntp` | Allows setting a custom URL for the new tab page.  Value can be internal (e.g. `about:blank`), external (e.g. `example.com`), or local (e.g. `file:///tmp/startpage.html`).  This applies for incognito windows as well when not set to a `chrome://` internal page.
+  `--hide-tab-close-buttons` | Hides the close buttons on tabs.
   `--pdf-plugin-name` | Sets the internal PDF viewer plugin name. Useful for sites that probe JavaScript API `navigator.plugins`. Supports values `chrome` for Chrome, `edge` for Microsoft Edge. Default value when omitted is Chromium.
   `--remove-grab-handle` | Removes the reserved empty space in the tabstrip for moving the window.
   `--remove-tabsearch-button` | Removes the tabsearch button from the tabstrip.

--- a/patches/extra/ungoogled-chromium/add-flag-for-tab-hover-cards.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-tab-hover-cards.patch
@@ -1,0 +1,65 @@
+--- a/chrome/browser/ui/views/tabs/tab.cc
++++ b/chrome/browser/ui/views/tabs/tab.cc
+@@ -12,6 +12,7 @@
+ #include <utility>
+ 
+ #include "base/bind.h"
++#include "base/command_line.h"
+ #include "base/debug/alias.h"
+ #include "base/i18n/rtl.h"
+ #include "base/metrics/user_metrics.h"
+@@ -641,6 +642,8 @@ void Tab::OnGestureEvent(ui::GestureEven
+ }
+ 
+ std::u16string Tab::GetTooltipText(const gfx::Point& p) const {
++  if (base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("tab-hover-cards") == "tooltip")
++    return GetTooltipText(data_.title, GetAlertStateToShow(data_.alert_state));
+   // Tab hover cards replace tooltips for tabs.
+   return std::u16string();
+ }
+--- a/chrome/browser/ui/views/tabs/tab_strip.cc
++++ b/chrome/browser/ui/views/tabs/tab_strip.cc
+@@ -15,6 +15,7 @@
+ 
+ #include "base/bind.h"
+ #include "base/callback.h"
++#include "base/command_line.h"
+ #include "base/compiler_specific.h"
+ #include "base/containers/adapters.h"
+ #include "base/containers/contains.h"
+@@ -2149,6 +2150,8 @@ void TabStrip::OnMouseEventInTab(views::
+ }
+ 
+ void TabStrip::UpdateHoverCard(Tab* tab, HoverCardUpdateType update_type) {
++  if (base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("tab-hover-cards") == "tooltip" ||
++      base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("tab-hover-cards") == "none") return;
+   // Some operations (including e.g. starting a drag) can cause the tab focus
+   // to change at the same time as the tabstrip is starting to animate; the
+   // hover card should not be visible at this time.
+--- a/chrome/browser/ungoogled_flag_choices.h
++++ b/chrome/browser/ungoogled_flag_choices.h
+@@ -75,4 +75,13 @@ const FeatureEntry::Choice kCloseConfirm
+      "close-confirmation",
+      "multiple"},
+ };
++const FeatureEntry::Choice kTabHoverCards[] = {
++    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
++    {"None",
++     "tab-hover-cards",
++     "none"},
++    {"Tooltip",
++     "tab-hover-cards",
++     "tooltip"},
++};
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_CHOICES_H_
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -88,4 +88,8 @@
+      "Custom New Tab Page",
+      "Allows setting a custom URL for the new tab page.  Value can be internal (e.g. `about:blank`), external (e.g. `example.com`), or local (e.g. `file:///tmp/startpage.html`).  This applies for incognito windows as well when not set to a `chrome://` internal page.  ungoogled-chromium flag",
+      kOsDesktop, ORIGIN_LIST_VALUE_TYPE("custom-ntp", "")},
++    {"tab-hover-cards",
++     "Tab Hover Cards",
++     "Allows removing the tab hover cards or using a tooltip as a replacement.  ungoogled-chromium flag.",
++     kOsDesktop, MULTI_VALUE_TYPE(kTabHoverCards)},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-to-hide-tab-close-buttons.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-hide-tab-close-buttons.patch
@@ -1,0 +1,22 @@
+--- a/chrome/browser/ui/views/tabs/tab_strip.cc
++++ b/chrome/browser/ui/views/tabs/tab_strip.cc
+@@ -1905,6 +1905,8 @@ bool TabStrip::SupportsMultipleSelection
+ }
+ 
+ bool TabStrip::ShouldHideCloseButtonForTab(Tab* tab) const {
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("hide-tab-close-buttons"))
++    return true;
+   if (tab->IsActive())
+     return false;
+   return !!touch_layout_;
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -92,4 +92,8 @@
+      "Tab Hover Cards",
+      "Allows removing the tab hover cards or using a tooltip as a replacement.  ungoogled-chromium flag.",
+      kOsDesktop, MULTI_VALUE_TYPE(kTabHoverCards)},
++    {"hide-tab-close-buttons",
++     "Hide tab close buttons",
++     "Hides the close buttons on tabs.  ungoogled-chromium flag.",
++     kOsDesktop, SINGLE_VALUE_TYPE("hide-tab-close-buttons")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/series
+++ b/patches/series
@@ -94,6 +94,7 @@ extra/ungoogled-chromium/add-flag-for-grab-handle.patch
 extra/ungoogled-chromium/add-flag-for-close-confirmation.patch
 extra/ungoogled-chromium/keep-expired-flags.patch
 extra/ungoogled-chromium/add-flag-for-custom-ntp.patch
+extra/ungoogled-chromium/add-flag-for-tab-hover-cards.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch

--- a/patches/series
+++ b/patches/series
@@ -95,6 +95,7 @@ extra/ungoogled-chromium/add-flag-for-close-confirmation.patch
 extra/ungoogled-chromium/keep-expired-flags.patch
 extra/ungoogled-chromium/add-flag-for-custom-ntp.patch
 extra/ungoogled-chromium/add-flag-for-tab-hover-cards.patch
+extra/ungoogled-chromium/add-flag-to-hide-tab-close-buttons.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch


### PR DESCRIPTION
This PR adds two new patches, the first one adds a flag that allows changing the tab hover cards to tooltips or remove them entirely.  The second patch adds a flag that allows hiding the tab close buttons which can be useful for some touch devices.  

Fixes #1683 and #1712