### PR TITLE
Add patch for DoH changes

### DIFF
--- a/patches/core/ungoogled-chromium/doh-changes.patch
+++ b/patches/core/ungoogled-chromium/doh-changes.patch
@@ -1,0 +1,70 @@
+--- a/chrome/common/chrome_features.cc
++++ b/chrome/common/chrome_features.cc
+@@ -309,12 +309,7 @@ const base::Feature kDesktopPWAsWebBundl
+ // Enable DNS over HTTPS (DoH).
+ const base::Feature kDnsOverHttps {
+   "DnsOverHttps",
+-#if defined(OS_WIN) || defined(OS_CHROMEOS) || defined(OS_MAC) || \
+-    defined(OS_ANDROID)
+-      base::FEATURE_ENABLED_BY_DEFAULT
+-#else
+       base::FEATURE_DISABLED_BY_DEFAULT
+-#endif
+ };
+ 
+ // Provides a mechanism to remove providers from the dropdown list in the
+@@ -331,12 +326,7 @@ const base::FeatureParam<bool> kDnsOverH
+ // Sets whether the DoH setting is displayed in the settings UI.
+ const base::FeatureParam<bool> kDnsOverHttpsShowUiParam {
+   &kDnsOverHttps, "ShowUi",
+-#if defined(OS_WIN) || defined(OS_CHROMEOS) || defined(OS_MAC) || \
+-    defined(OS_ANDROID)
+       true
+-#else
+-      false
+-#endif
+ };
+ 
+ // Supply one or more space-separated DoH server URI templates to use when this
+--- a/net/dns/public/doh_provider_entry.cc
++++ b/net/dns/public/doh_provider_entry.cc
+@@ -117,24 +117,6 @@ const DohProviderEntry::List& DohProvide
+           /*privacy_policy=*/"https://dns.sb/privacy/",
+           /*display_globally=*/false, /*display_countries=*/{"EE", "DE"},
+           LoggingLevel::kNormal),
+-      new DohProviderEntry("Google", DohProviderIdForHistogram::kGoogle,
+-                           {"8.8.8.8", "8.8.4.4", "2001:4860:4860::8888",
+-                            "2001:4860:4860::8844"},
+-                           {"dns.google", "dns.google.com",
+-                            "8888.google"} /* dns_over_tls_hostnames */,
+-                           "https://dns.google/dns-query{?dns}",
+-                           "Google (Public DNS)" /* ui_name */,
+-                           "https://developers.google.com/speed/public-dns/"
+-                           "privacy" /* privacy_policy */,
+-                           true /* display_globally */,
+-                           {} /* display_countries */, LoggingLevel::kExtra),
+-      new DohProviderEntry(
+-          "GoogleDns64", absl::nullopt /* provider_id_for_histogram */,
+-          {"2001:4860:4860::64", "2001:4860:4860::6464"},
+-          {"dns64.dns.google"} /* dns_over_tls_hostnames */,
+-          "https://dns64.dns.google/dns-query{?dns}", "" /* ui_name */,
+-          "" /* privacy_policy */, false /* display_globally */,
+-          {} /* display_countries */, LoggingLevel::kNormal),
+       new DohProviderEntry("Iij", DohProviderIdForHistogram::kIij,
+                            {} /* ip_strs */, {} /* dns_over_tls_hostnames */,
+                            "https://public.dns.iij.jp/dns-query",
+--- a/services/network/public/cpp/features.cc
++++ b/services/network/public/cpp/features.cc
+@@ -113,12 +113,7 @@ const base::Feature kSplitAuthCacheByNet
+ // Enable usage of hardcoded DoH upgrade mapping for use in automatic mode.
+ const base::Feature kDnsOverHttpsUpgrade {
+   "DnsOverHttpsUpgrade",
+-#if BUILDFLAG(IS_CHROMEOS_ASH) || defined(OS_MAC) || defined(OS_ANDROID) || \
+-    defined(OS_WIN)
+-      base::FEATURE_ENABLED_BY_DEFAULT
+-#else
+       base::FEATURE_DISABLED_BY_DEFAULT
+-#endif
+ };
+ 
+ // If this feature is enabled, the mDNS responder service responds to queries

--- a/patches/series
+++ b/patches/series
@@ -35,6 +35,7 @@ core/ungoogled-chromium/fix-building-without-enabling-reporting.patch
 core/ungoogled-chromium/block-requests.patch
 core/ungoogled-chromium/disable-floc.patch
 core/ungoogled-chromium/disable-privacy-sandbox.patch
+core/ungoogled-chromium/doh-changes.patch
 core/bromite/disable-fetching-field-trials.patch
 
 extra/inox-patchset/0006-modify-default-prefs.patch


### PR DESCRIPTION
This PR adds a new core patch that makes a few changes to DNS over HTTPS (DoH):
* Removes Google DoH servers from the list of providers.  This was previously missed by the domain substitution since it doesn't match on IP addresses.  If you had manually set Google's DoH server as your provider before this patch then the entry will become a custom entry after this patch is applied.  
* Allows enabling DoH on linux.  DoH works fine on linux and many other chormium-based browsers enable this for the platform.  
* Disables DoH by default.  It's best to respect the system's DNS settings by default while allowing users to enable DoH if they need it.  
* Disables DoH auto upgrade.  The browser shouldn't be changing servers without the user's consent.  Before the Google servers were removed this had the potential to upgrade to their servers without the user's knowledge.  

Fixes #1515