### PR TITLE
Update stale issues and PRs workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,3 +16,7 @@ jobs:
             with:
                 exempt-all-milestones: true
                 any-of-labels: 'need info'
+                days-before-stale: 30
+                days-before-close: 7
+                stale-issue-message: "This issue has been automatically marked as stale as there has been no recent activity in response to our request for more information. Please respond so that we can proceed with this issue."
+                close-issue-message: "This issue has been automatically closed as sufficient information hasn't been provided on the issue for further actions to be taken. Feel free to add more information."


### PR DESCRIPTION
* Changed the default 60/7 days of inactivity to 14/14.
* Plus messages to convey the stale'ing and closing of the issues.

I'd like to hear from you all regarding the following:
1. I believe that default 60 days is way too much, but not certain if 14 is a reasonable value either. What you think?
2. How do you like the wording of the messages? Are they concise and make the point clear?