### PR TITLE
Update mDNS patch for local IP obfuscation

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -65,3 +65,17 @@ These are also available on the `chrome://flags` page.
   -- | --
   `ClearDataOnExit` | Clears all browsing data on exit.
   `DisableQRGenerator` | Disables the QR generator for sharing page links.
+
+
+<br>
+
+---
+
+<br>
+
+
+# Existing Chromium flags
+
+Behavior for existing Chromium flags is normally not altered, but due to build flags or other core modifications used by ungoogled-chromium some exceptions may apply:
+
+* `WebRtcHideLocalIpsWithMdns`:  This feature flag does not use mDNS to hide the local IP since ungoogled-chromium is built with `enable_mds=false`.  A randomized address will be provided instead.  

--- a/patches/extra/ungoogled-chromium/fix-building-without-mdns-and-service-discovery.patch
+++ b/patches/extra/ungoogled-chromium/fix-building-without-mdns-and-service-discovery.patch
@@ -40,3 +40,22 @@
  }
  
  }  // namespace media_router
+--- a/third_party/webrtc/p2p/client/basic_port_allocator.cc
++++ b/third_party/webrtc/p2p/client/basic_port_allocator.cc
+@@ -33,6 +33,7 @@
+ #include "rtc_base/trace_event.h"
+ #include "system_wrappers/include/field_trial.h"
+ #include "system_wrappers/include/metrics.h"
++#include "third_party/blink/public/common/features.h"
+ 
+ using rtc::CreateRandomId;
+ 
+@@ -565,7 +566,7 @@ void BasicPortAllocatorSession::GetCandi
+ }
+ 
+ bool BasicPortAllocator::MdnsObfuscationEnabled() const {
+-  return network_manager()->GetMdnsResponder() != nullptr;
++  return base::FeatureList::IsEnabled(blink::features::kWebRtcHideLocalIpsWithMdns);
+ }
+ 
+ bool BasicPortAllocatorSession::CandidatesAllocationDone() const {

--- a/patches/extra/ungoogled-chromium/fix-building-without-mdns-and-service-discovery.patch
+++ b/patches/extra/ungoogled-chromium/fix-building-without-mdns-and-service-discovery.patch
@@ -40,6 +40,25 @@
  }
  
  }  // namespace media_router
+--- a/third_party/webrtc/api/candidate.cc
++++ b/third_party/webrtc/api/candidate.cc
+@@ -10,6 +10,7 @@
+ 
+ #include "api/candidate.h"
+ 
++#include "base/guid.h"
+ #include "rtc_base/helpers.h"
+ #include "rtc_base/ip_address.h"
+ #include "rtc_base/logging.h"
+@@ -135,7 +136,7 @@ Candidate Candidate::ToSanitizedCopy(boo
+     rtc::IPAddress ip;
+     if (address().hostname().empty()) {
+       // IP needs to be redacted, but no hostname available.
+-      rtc::SocketAddress redacted_addr("redacted-ip.invalid", address().port());
++      rtc::SocketAddress redacted_addr(base::GenerateGUID() + ".local", address().port());
+       copy.set_address(redacted_addr);
+     } else if (IPFromString(address().hostname(), &ip)) {
+       // The hostname is an IP literal, and needs to be redacted too.
 --- a/third_party/webrtc/p2p/client/basic_port_allocator.cc
 +++ b/third_party/webrtc/p2p/client/basic_port_allocator.cc
 @@ -33,6 +33,7 @@


### PR DESCRIPTION
This PR adds a change to the existing mDNS patch which allows local IP obfuscation when building with `enable_mds=false`.  

`kWebRtcHideLocalIpsWithMdns` is enabled by default in Chromium and replaces the local IP returned via WebRTC with an address that is resolvable on the local network using mDNS.  This can be disabled with `chrome://flags/#enable-webrtc-hide-local-ips-with-mdns`.  

Interestingly, the sanitation of the local IP address doesn't rely on mDNS at all!  The obfuscation can be enabled based on the flag's state rather than the existence of the mDNS responder which would be created from that flag.  The address is not replaced with the mDNS-accessible one since it's not enabled.  

<sub>Normally, with mDNS enabled:</sub>
![Screenshot_20211128_095916](https://user-images.githubusercontent.com/40727284/143778825-0cc2dd23-643c-406c-9a36-923c774080c8.png)

<sub>Without mDNS:</sub>
![Screenshot_20211128_095520](https://user-images.githubusercontent.com/40727284/143778831-59af8b23-05dd-46e1-a462-8b90cbb9045a.png)

This allows the browser to function similarly to vanilla Chromium and utilizes the existing flag as well.  It's a bit of misnomer since it isn't using mDNS, but most end users searching to change this behavior would end up landing on the `WebRtcHideLocalIpsWithMdns` feature flag.  

Fixes #1725

---
Notes:

I used the sites in the linked issue to test:  https://tenta.com/test/  and  https://browserleaks.com/webrtc

uBlock Origin had an option to hide the local IP returned with WebRTC and has since removed that option since Chromium added the obfuscation.  It seems that only the option itself was removed, so if you had that enabled previously then it should still be functioning and the local IP would be shown on tenta as `UNKNOWN`!  