### PR TITLE
Add flag for referrer header directive

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -22,6 +22,7 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--max-connections-per-host` | (from Bromite) Configure the maximum allowed connections per host. Valid values are `6` and `15`
   `--omnibox-autocomplete-filtering` | Restrict omnibox autocomplete results to a combination of search suggestions (if enabled), bookmarks, and internal chrome pages.  Accepts `search`, `search-bookmarks`, `search-chrome`, and `search-bookmarks-chrome`.
   `--popups-to-tabs` | Makes popups open in new tabs.
+  `--referrer-directive` | Allows setting a custom directive for referrer headers. Accepts `nocrossorigin`, `minimal`, and `noreferrers`. The no cross-origin referrer option removes all cross-origin referrers, the minimal option removes all cross-origin referrers and strips same-origin referrers down to the origin, and the no referrers option removes all referrers.
 
 - ### Available only on desktop
 

--- a/patches/extra/ungoogled-chromium/add-flag-for-referrer-header.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-referrer-header.patch
@@ -30,7 +30,7 @@
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/content/browser/utility_process_host.cc
 +++ b/content/browser/utility_process_host.cc
-@@ -224,6 +224,7 @@ bool UtilityProcessHost::StartProcess()
+@@ -225,6 +225,7 @@ bool UtilityProcessHost::StartProcess()
  
      // Browser command-line switches to propagate to the utility process.
      static const char* const kSwitchNames[] = {

--- a/patches/extra/ungoogled-chromium/add-flag-for-referrer-header.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-referrer-header.patch
@@ -1,0 +1,66 @@
+--- a/chrome/browser/ungoogled_flag_choices.h
++++ b/chrome/browser/ungoogled_flag_choices.h
+@@ -79,4 +79,16 @@ const FeatureEntry::Choice kTabHoverCard
+      "tab-hover-cards",
+      "tooltip"},
+ };
++const FeatureEntry::Choice kReferrerDirective[] = {
++    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
++    {"No cross-origin referrer",
++     "referrer-directive",
++     "nocrossorigin"},
++    {"Minimal referrer",
++     "referrer-directive",
++     "minimal"},
++    {"No referrers",
++     "referrer-directive",
++     "noreferrers"},
++};
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_CHOICES_H_
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -88,4 +88,8 @@
+      "Hide tab close buttons",
+      "Hides the close buttons on tabs.  ungoogled-chromium flag.",
+      kOsDesktop, SINGLE_VALUE_TYPE("hide-tab-close-buttons")},
++    {"referrer-directive",
++     "Referrer directive",
++     "Allows setting a custom directive for referrer headers.  The no cross-origin referrer option removes all cross-origin referrers, the minimal option removes all cross-origin referrers and strips same-origin referrers down to the origin, and the no referrers option removes all referrers.  ungoogled-chromium flag.",
++     kOsAll, MULTI_VALUE_TYPE(kReferrerDirective)},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
+--- a/content/browser/utility_process_host.cc
++++ b/content/browser/utility_process_host.cc
+@@ -224,6 +224,7 @@ bool UtilityProcessHost::StartProcess()
+ 
+     // Browser command-line switches to propagate to the utility process.
+     static const char* const kSwitchNames[] = {
++      "referrer-directive",
+       network::switches::kAdditionalTrustTokenKeyCommitments,
+       network::switches::kForceEffectiveConnectionType,
+       network::switches::kHostResolverRules,
+--- a/services/network/network_service_network_delegate.cc
++++ b/services/network/network_service_network_delegate.cc
+@@ -7,6 +7,7 @@
+ #include <string>
+ 
+ #include "base/bind.h"
++#include "base/command_line.h"
+ #include "base/debug/dump_without_crashing.h"
+ #include "base/strings/utf_string_conversions.h"
+ #include "build/build_config.h"
+@@ -62,6 +63,15 @@ void NetworkServiceNetworkDelegate::Mayb
+     return;
+   }
+ 
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("referrer-directive")) {
++    std::string option = base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("referrer-directive");
++    if (!url::IsSameOriginWith(effective_url, GURL(request->referrer())) || option == "noreferrers")
++      request->SetReferrer(std::string());
++    if (option == "minimal")
++      request->SetReferrer(url::Origin::Create(GURL(request->referrer())).GetURL().spec());
++    return;
++  }
++
+   if (base::FeatureList::IsEnabled(
+           net::features::kCapReferrerToOriginOnCrossOrigin)) {
+     if (!url::IsSameOriginWith(effective_url, GURL(request->referrer()))) {

--- a/patches/series
+++ b/patches/series
@@ -93,6 +93,7 @@ extra/ungoogled-chromium/add-flag-for-custom-ntp.patch
 extra/ungoogled-chromium/add-flag-for-tab-hover-cards.patch
 extra/ungoogled-chromium/add-flag-to-hide-tab-close-buttons.patch
 extra/ungoogled-chromium/disable-remote-optimization-guide.patch
+extra/ungoogled-chromium/add-flag-for-referrer-header.patch
 extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
 extra/bromite/flag-max-connections-per-host.patch
 extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch


### PR DESCRIPTION
This PR adds a patch that allows changing the amount of information passed through the referrer header.  
Using the no cross-origin option removes the referrer for cross-origin requests, while the minimal option also strips same-origin referrers to just the origin instead of the full URL.  

This can help prevent tracking, but in some instances can also cause some problems for sites that rely on the referrer to function correctly.  
The referrer header can be disabled completely by launching with the existing feature:  `--enable-features=NoReferrers`.  

Fixes #1918 