### PR TITLE
Adjust argument length assertion in add-suggestions-url patch

### DIFF
--- a/patches/extra/ungoogled-chromium/add-suggestions-url-field.patch
+++ b/patches/extra/ungoogled-chromium/add-suggestions-url-field.patch
@@ -379,7 +379,12 @@
    else
      NOTREACHED();
  
-@@ -373,14 +380,17 @@ void SearchEnginesHandler::HandleSearchE
+@@ -369,18 +376,21 @@ void SearchEnginesHandler::HandleSearchE
+   if (!edit_controller_.get())
+     return;
+ 
+-  CHECK_EQ(3U, args.size());
++  CHECK_EQ(4U, args.size());
    const std::string& search_engine = args[0].GetString();
    const std::string& keyword = args[1].GetString();
    const std::string& query_url = args[2].GetString();


### PR DESCRIPTION
Chromium commit https://source.chromium.org/chromium/chromium/src/+/d30ba01286cdedafe6a77e91950854da81acb4f4
added an assertion to check that the args list has a size of 3. As the
patch adds the suggestions url as an additional argument, the browser
would crash when reaching the code.

This only affects ungoogled-chromium release 102.0.5005.61-1 as previous
chromium releases didn't include this commit.

First reported here https://github.com/ungoogled-software/ungoogled-chromium-archlinux/issues/189.

