### PR TITLE
Fix SSL error bypass

### DIFF
--- a/patches/core/inox-patchset/0001-fix-building-without-safebrowsing.patch
+++ b/patches/core/inox-patchset/0001-fix-building-without-safebrowsing.patch
@@ -187,7 +187,7 @@
  }
  
  bool ChromeContentBrowserClient::IsBrowserStartupComplete() {
-@@ -4290,18 +4261,6 @@ ChromeContentBrowserClient::CreateThrott
+@@ -4290,14 +4261,9 @@ ChromeContentBrowserClient::CreateThrott
    throttles.push_back(std::make_unique<PolicyBlocklistNavigationThrottle>(
        handle, handle->GetWebContents()->GetBrowserContext()));
  
@@ -196,17 +196,14 @@
 -  SSLErrorHandler::SetClientCallbackOnInterstitialsShown(
 -      base::BindRepeating(&MaybeTriggerSecurityInterstitialShownEvent));
 -  content::WebContents* web_contents = handle->GetWebContents();
--  throttles.push_back(std::make_unique<SSLErrorNavigationThrottle>(
--      handle,
+   throttles.push_back(std::make_unique<SSLErrorNavigationThrottle>(
+       handle,
 -      std::make_unique<CertificateReportingServiceCertReporter>(web_contents),
--      base::BindOnce(&HandleSSLErrorWrapper), base::BindOnce(&IsInHostedApp),
--      base::BindOnce(
--          &ShouldIgnoreSslInterstitialBecauseNavigationDefaultedToHttps)));
--
-   throttles.push_back(std::make_unique<LoginNavigationThrottle>(handle));
- 
-   if (base::FeatureList::IsEnabled(omnibox::kDefaultTypedNavigationsToHttps)) {
-@@ -4332,16 +4291,6 @@ ChromeContentBrowserClient::CreateThrott
++      nullptr,
+       base::BindOnce(&HandleSSLErrorWrapper), base::BindOnce(&IsInHostedApp),
+       base::BindOnce(
+           &ShouldIgnoreSslInterstitialBecauseNavigationDefaultedToHttps)));
+@@ -4332,16 +4298,6 @@ ChromeContentBrowserClient::CreateThrott
                     &throttles);
  #endif
  

--- a/patches/core/ungoogled-chromium/fix-building-without-safebrowsing.patch
+++ b/patches/core/ungoogled-chromium/fix-building-without-safebrowsing.patch
@@ -73,7 +73,7 @@
    auto delegate = std::make_unique<AccuracyServiceDelegate>(profile);
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -4291,11 +4291,13 @@ ChromeContentBrowserClient::CreateThrott
+@@ -4298,11 +4298,13 @@ ChromeContentBrowserClient::CreateThrott
                     &throttles);
  #endif
  
@@ -87,7 +87,7 @@
  
  // TODO(crbug.com/1052397): Revisit the macro expression once build flag switch
  // of lacros-chrome is complete.
-@@ -5692,26 +5694,7 @@ ChromeContentBrowserClient::GetSafeBrows
+@@ -5699,26 +5701,7 @@ ChromeContentBrowserClient::GetSafeBrows
      const std::vector<std::string>& allowlist_domains) {
    DCHECK_CURRENTLY_ON(BrowserThread::IO);
  
@@ -115,7 +115,7 @@
  }
  
  safe_browsing::RealTimeUrlLookupServiceBase*
-@@ -5732,11 +5715,6 @@ ChromeContentBrowserClient::GetUrlLookup
+@@ -5739,11 +5722,6 @@ ChromeContentBrowserClient::GetUrlLookup
          GetForProfile(profile);
    }
  #endif


### PR DESCRIPTION
This PR fixes #1974 and #1972.  I had removed the SSLErrorNavigationThrottle along with the other changes in 102 which caused there to not be bypass buttons for SSL error pages.  