### PR TITLE
Enable Certificate Transparency Enforcement

### DIFF
--- a/patches/extra/ungoogled-chromium/enable-certificate-transparency-and-add-flag.patch
+++ b/patches/extra/ungoogled-chromium/enable-certificate-transparency-and-add-flag.patch
@@ -1,0 +1,22 @@
+--- a/chrome/browser/browser_features.cc
++++ b/chrome/browser/browser_features.cc
+@@ -50,7 +50,7 @@ BASE_FEATURE(kBookmarkTriggerForPrerender2,
+ // switch.
+ BASE_FEATURE(kCertificateTransparencyAskBeforeEnabling,
+              "CertificateTransparencyAskBeforeEnabling",
+-#if BUILDFLAG(GOOGLE_CHROME_BRANDING)
++#if true
+              base::FEATURE_ENABLED_BY_DEFAULT);
+ #else
+              base::FEATURE_DISABLED_BY_DEFAULT);
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -140,4 +140,8 @@
+      "Spoof WebGL Info",
+      "Return generic values for WebGLDebugRendererInfo to remove a potential data leak while preventing potential website breakage. ungoogled-chromium flag.",
+      kOsAll, FEATURE_WITH_PARAMS_VALUE_TYPE(blink::features::kSpoofWebGLInfo, kSpoofWebGLChoices, "SpoofWebGLInfo")},
++    {"enforce-certificate-transparency",
++     "Enforce Certificate Transparency",
++     "Enforce Certificate Transparency for certificates that sites present. This is enabled by default. ungoogled-chromium flag.",
++     kOsAll, FEATURE_VALUE_TYPE(features::kCertificateTransparencyAskBeforeEnabling)},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/enable-certificate-transparency-and-add-flag.patch
+++ b/patches/extra/ungoogled-chromium/enable-certificate-transparency-and-add-flag.patch
@@ -14,7 +14,7 @@
 @@ -140,4 +140,8 @@
       "Spoof WebGL Info",
       "Return generic values for WebGLDebugRendererInfo to remove a potential data leak while preventing potential website breakage. ungoogled-chromium flag.",
-      kOsAll, FEATURE_WITH_PARAMS_VALUE_TYPE(blink::features::kSpoofWebGLInfo, kSpoofWebGLChoices, "SpoofWebGLInfo")},
+      kOsAll, FEATURE_VALUE_TYPE(blink::features::kSpoofWebGLInfo)},
 +    {"enforce-certificate-transparency",
 +     "Enforce Certificate Transparency",
 +     "Enforce Certificate Transparency for certificates that sites present. This is enabled by default. ungoogled-chromium flag.",

--- a/patches/series
+++ b/patches/series
@@ -110,3 +110,4 @@ extra/ungoogled-chromium/enable-extra-locales.patch
 extra/ungoogled-chromium/disable-chromelabs.patch
 extra/ungoogled-chromium/remove-pac-size-limit.patch
 extra/ungoogled-chromium/add-flag-to-spoof-webgl-renderer-info.patch
+extra/ungoogled-chromium/enable-certificate-transparency-and-add-flag.patch


### PR DESCRIPTION
Enabled by default because it improves security and is the default on Chrome. There's a flag added anyways in case it goes haywire and needs to be disabled.

closes https://github.com/ungoogled-software/ungoogled-chromium/issues/3242

