### PR TITLE
Disable all Google AI starter pack `@shortcuts`

### DIFF
--- a/patches/extra/ungoogled-chromium/disable-ai-search-shortcuts.patch
+++ b/patches/extra/ungoogled-chromium/disable-ai-search-shortcuts.patch
@@ -1,0 +1,42 @@
+--- a/chrome/browser/ui/search_engines/template_url_table_model.cc
++++ b/chrome/browser/ui/search_engines/template_url_table_model.cc
+@@ -119,12 +119,11 @@ void TemplateURLTableModel::Reload() {
+   for (TemplateURL* template_url : urls) {
+     // Don't include the expanded set of starter pack keywords if the expansion
+     // feature flag is not enabled.
+-    if ((template_url->starter_pack_id() ==
+-             template_url_starter_pack_data::kGemini &&
+-         !OmniboxFieldTrial::IsStarterPackExpansionEnabled()) ||
+-        (template_url->starter_pack_id() ==
+-             template_url_starter_pack_data::kPage &&
+-         !omnibox_feature_configs::ContextualSearch::Get().starter_pack_page)) {
++
++    // Disable all Google AI starter pack options
++    if (template_url->starter_pack_id() == template_url_starter_pack_data::kGemini ||
++        template_url->starter_pack_id() == template_url_starter_pack_data::kAiMode ||
++        template_url->starter_pack_id() == template_url_starter_pack_data::kPage) {
+       continue;
+     }
+ 
+--- a/components/omnibox/browser/featured_search_provider.cc
++++ b/components/omnibox/browser/featured_search_provider.cc
+@@ -291,13 +291,14 @@ void FeaturedSearchProvider::AddFeatured
+         turl->is_active() == TemplateURLData::ActiveStatus::kTrue) {
+       // Don't add the expanded set of starter pack engines unless the feature
+       // is enabled.
+-      if ((turl->starter_pack_id() == template_url_starter_pack_data::kGemini &&
+-           !OmniboxFieldTrial::IsStarterPackExpansionEnabled()) ||
+-          (turl->starter_pack_id() == template_url_starter_pack_data::kPage &&
+-           !omnibox_feature_configs::ContextualSearch::Get()
+-                .starter_pack_page)) {
++
++      // Disable all Google AI starter pack options
++      if (turl->starter_pack_id() == template_url_starter_pack_data::kGemini ||
++          turl->starter_pack_id() == template_url_starter_pack_data::kAiMode ||
++          turl->starter_pack_id() == template_url_starter_pack_data::kPage) {
+         continue;
+       }
++
+       // The history starter pack engine is disabled in incognito mode.
+       if (client_->IsOffTheRecord() &&
+           turl->starter_pack_id() == template_url_starter_pack_data::kHistory) {

--- a/patches/series
+++ b/patches/series
@@ -112,3 +112,4 @@ extra/ungoogled-chromium/enable-certificate-transparency-and-add-flag.patch
 extra/ungoogled-chromium/add-flag-to-spoof-webgl-renderer-info.patch
 extra/ungoogled-chromium/add-flag-to-increase-incognito-storage-quota.patch
 extra/ungoogled-chromium/add-credits.patch
+extra/ungoogled-chromium/disable-ai-search-shortcuts.patch


### PR DESCRIPTION
This PR disables all AI-related starter pack shortcuts: `@gemini`, `@aimode`, and `@page` (the last one is currently disabled behind a flag).

The [existing patch](https://github.com/ungoogled-software/ungoogled-chromium/blob/a078b9be0f51f5b866edc0fd21996d4c7816f07f/patches/extra/ungoogled-chromium/prepopulated-search-engines.patch) that removes `@gemini` via `kStarterPackExpansion` doesn't disable the newly added `@aimode`, despite the two being (very) closely related. This seems to be due to an oversight on Google's part, because `@aimode` gating [was fixed two days ago in main](https://chromium-review.googlesource.com/c/chromium/src/+/6729947), but it is still not controlled by `kStarterPackExpansion`.

Since it's unknown when the `@aimode` gating fix will land in a release build, I think it's best to disable it and the other shortcuts by other means (at least for now). This patch will have to be refactored in the future, but I generally think this is a better approach to removing these shortcuts for good. It also ensures that profiles created with `@aimode` enabled will not have it after the merge.

Before:
<img width="1200" height="866" alt="image" src="https://github.com/user-attachments/assets/ad163701-ad76-45b4-b57e-9e93711430e1" />

After (same profile):
<img width="1200" height="866" alt="image" src="https://github.com/user-attachments/assets/ee7026ea-9570-4d6c-9c58-b341c03b8adb" />
