### PR TITLE
devutils/platform_patches: update shared patches instead of deleting

### DIFF
--- a/devutils/update_platform_patches.py
+++ b/devutils/update_platform_patches.py
@@ -63,17 +63,19 @@ def _dir_empty(path):
     return False
 
 
-def _remove_files_with_dirs(root_dir, sorted_file_iter):
+def _rename_files_with_dirs(root_dir, source_dir, sorted_file_iter):
     '''
-    Deletes a list of sorted files relative to root_dir, removing empty directories along the way
+    Moves a list of sorted files back to their original location,
+    removing empty directories along the way
     '''
     past_parent = None
     for partial_path in sorted_file_iter:
         complete_path = Path(root_dir, partial_path)
+        complete_source_path = Path(source_dir, partial_path)
         try:
-            complete_path.unlink()
+            complete_path.rename(complete_source_path)
         except FileNotFoundError:
-            get_logger().warning('Could not remove prepended patch: %s', complete_path)
+            get_logger().warning('Could not move prepended patch: %s', complete_path)
         if past_parent != complete_path.parent:
             while past_parent and _dir_empty(past_parent):
                 past_parent.rmdir()
@@ -85,7 +87,7 @@ def _remove_files_with_dirs(root_dir, sorted_file_iter):
         complete_path = complete_path.parent
 
 
-def unmerge_platform_patches(platform_patches_dir):
+def unmerge_platform_patches(platform_patches_dir, prepend_patches_dir):
     '''
     Undo merge_platform_patches(), adding any new patches from series.merged as necessary
 
@@ -99,8 +101,8 @@ def unmerge_platform_patches(platform_patches_dir):
         filter(len,
                (platform_patches_dir / _SERIES_PREPEND).read_text(encoding=ENCODING).splitlines()))
 
-    # Remove prepended files with directories
-    _remove_files_with_dirs(platform_patches_dir, sorted(prepend_series))
+    # Move prepended files back to original location, preserving changes
+    _rename_files_with_dirs(platform_patches_dir, prepend_patches_dir, sorted(prepend_series))
 
     # Determine positions of blank spaces in series.orig
     if not (platform_patches_dir / _SERIES_ORIG).exists():
@@ -169,10 +171,11 @@ def main():
     repo_dir = Path(__file__).resolve().parent.parent
 
     success = False
+    prepend_patches_dir = repo_dir / 'patches'
     if args.command == 'merge':
-        success = merge_platform_patches(args.platform_patches, repo_dir / 'patches')
+        success = merge_platform_patches(args.platform_patches, prepend_patches_dir)
     elif args.command == 'unmerge':
-        success = unmerge_platform_patches(args.platform_patches)
+        success = unmerge_platform_patches(args.platform_patches, prepend_patches_dir)
     else:
         raise NotImplementedError(args.command)
 


### PR DESCRIPTION
Instead of deleting copies of generic patches when unmerging them from platform patches, move them back into the shared repository.

This makes it much more pleasant and ergonomic to work on shared patches in a merged series, and allows to refresh, or otherwise modify existing patches by "unmerging", instead of having to move them back to the original folder manually.

My case for why this potentially breaking change should be made: I have been using this as a personal preference in helium for a few months: imputnet/helium@d56c8d5677107f01ac90049f537a43325a57ae8b, and it has made working with patch series much simpler - so much that I believe it should be a default everywhere. To my knowledge, it should not break any build processes, since unmerging is usually done as a manual action by a human when working on patches.