### PR TITLE
Enable NoCrossOriginReferrers flag by default

### DIFF
--- a/patches/extra/ungoogled-chromium/add-flags-for-referrer-customization.patch
+++ b/patches/extra/ungoogled-chromium/add-flags-for-referrer-customization.patch
@@ -121,7 +121,7 @@
 +
 +BASE_FEATURE(kNoCrossOriginReferrers,
 +             "NoCrossOriginReferrers",
-+             base::FEATURE_DISABLED_BY_DEFAULT);
++             base::FEATURE_ENABLED_BY_DEFAULT);
 +
  
  // Enables the Accept-CH support disabler. If this feature is activated, Chrome


### PR DESCRIPTION
Disable cross-origin referrers by default while keeping same-origin referrers enabled to balance privacy and usability.
