### PR TITLE
patches/disable-crash-reporter: re-enable crashpad on Linux

### DIFF
--- a/patches/core/ungoogled-chromium/disable-crash-reporter.patch
+++ b/patches/core/ungoogled-chromium/disable-crash-reporter.patch
@@ -1,69 +1,49 @@
 # Disable some background communication with clients2.google.com
 
---- a/chrome/browser/chrome_content_browser_client.cc
-+++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -2683,24 +2683,6 @@ void ChromeContentBrowserClient::AppendE
-     command_line->AppendSwitchASCII(switches::kMetricsClientID,
-                                     client_info->client_id);
-   }
--#elif BUILDFLAG(IS_POSIX)
--#if !BUILDFLAG(IS_ANDROID)
--  pid_t pid;
--  if (crash_reporter::GetHandlerSocket(nullptr, &pid)) {
--    command_line->AppendSwitchASCII(
--        crash_reporter::switches::kCrashpadHandlerPid,
--        base::NumberToString(pid));
--  }
--#endif
--  std::string switch_value;
--  std::unique_ptr<metrics::ClientInfo> client_info =
--      GoogleUpdateSettings::LoadMetricsClientInfo();
--  if (client_info) {
--    switch_value = client_info->client_id;
--  }
--  switch_value.push_back(',');
--  switch_value.append(chrome::GetChannelName(chrome::WithExtendedStable(true)));
--  command_line->AppendSwitchASCII(switches::kEnableCrashReporter, switch_value);
+--- a/components/crash/core/app/crash_reporter_client.cc
++++ b/components/crash/core/app/crash_reporter_client.cc
+@@ -146,7 +146,7 @@ void CrashReporterClient::GetSanitizatio
  #endif
  
-   if (logging::DialogsAreSuppressed()) {
+ std::string CrashReporterClient::GetUploadUrl() {
+-#if BUILDFLAG(GOOGLE_CHROME_BRANDING) && defined(OFFICIAL_BUILD)
++#if 0
+   return kDefaultUploadURL;
+ #else
+   return std::string();
+--- a/third_party/crashpad/crashpad/handler/handler_main.cc
++++ b/third_party/crashpad/crashpad/handler/handler_main.cc
+@@ -875,7 +875,7 @@ int HandlerMain(int argc,
+ #endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) ||
+         // BUILDFLAG(IS_ANDROID)
+       case kOptionURL: {
+-        options.url = optarg;
++        options.url = "";
+         break;
+       }
+ #if BUILDFLAG(IS_CHROMEOS)
+@@ -1016,7 +1016,7 @@ int HandlerMain(int argc,
+   }
+ 
+   ScopedStoppable upload_thread;
+-  if (!options.url.empty()) {
++  if ((false)) {
+     // TODO(scottmg): options.rate_limit should be removed when we have a
+     // configurable database setting to control upload limiting.
+     // See https://crashpad.chromium.org/bug/23.
 --- a/components/crash/core/app/crashpad.cc
 +++ b/components/crash/core/app/crashpad.cc
-@@ -72,6 +72,12 @@ void InitializeDatabasePath(const base::
- }
- 
- bool InitializeCrashpadImpl(bool initial_client,
-+    const std::string& a, const std::string& b, const base::FilePath& c,
-+    const std::vector<std::string>& d, bool e, const std::vector<base::FilePath>& f) {
+@@ -78,6 +78,13 @@ bool InitializeCrashpadImpl(bool initial
+                             const std::vector<std::string>& initial_arguments,
+                             bool embedded_handler,
+                             const std::vector<base::FilePath>& attachments) {
++// Crashpad is needed on Linux because it's used as a WASM signal handler.
++// This is not the case on other platforms, and so it can remain entirely
++// disabled there.
++#if !BUILDFLAG(IS_LINUX)
 +  return false;
-+}
-+[[maybe_unused]]
-+bool DeadInitializeCrashpadImpl(bool initial_client,
-                             const std::string& process_type,
-                             const std::string& user_data_dir,
-                             const base::FilePath& exe_path,
---- a/components/gwp_asan/client/gwp_asan.cc
-+++ b/components/gwp_asan/client/gwp_asan.cc
-@@ -344,6 +344,11 @@ GWP_ASAN_EXPORT std::optional<AllocatorS
- 
- // Exported for testing.
- GWP_ASAN_EXPORT std::optional<AllocatorSettings> GetAllocatorSettings(
-+    const base::Feature& a, bool b, std::string_view c) {
-+  return std::nullopt;
-+}
-+[[maybe_unused]]
-+std::optional<AllocatorSettings> DeadGetAllocatorSettings(
-     const base::Feature& feature,
-     bool boost_sampling,
-     std::string_view process_type) {
---- a/third_party/crashpad/crashpad/client/crashpad_client_linux.cc
-+++ b/third_party/crashpad/crashpad/client/crashpad_client_linux.cc
-@@ -747,8 +747,6 @@ void CrashpadClient::CrashWithoutDump(co
- // static
- void CrashpadClient::SetFirstChanceExceptionHandler(
-     FirstChanceHandler handler) {
--  DCHECK(SignalHandler::Get());
--  SignalHandler::Get()->SetFirstChanceHandler(handler);
- }
- 
- // static
++#endif
++
+   static bool initialized = false;
+   DCHECK(!initialized);
+   initialized = true;


### PR DESCRIPTION
Fixes #3333 by re-enabling Crashpad specifically on Linux, since Chromium relies on it (for whatever reason) as a [signal handler for WASM JIT stuff](https://source.chromium.org/chromium/chromium/src/+/main:chrome/app/chrome_main_delegate.cc;l=1576;drc=b2d540b15cad394746b9277911ae1192f25158aa;bpv=0;bpt=1). 

The crashpad handler should not generate any traffic even by default, since the URL is currently gated behind `BUILDFLAG(GOOGLE_CHROME_BRANDING)` (and domain substitution should otherwise catch it anyways), but I added some safeguards just in case anything changes.