### PR TITLE
Clarify Matrix room address in SUPPORT.md

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -13,7 +13,7 @@ There are a few channels for support:
 * An issue tracker. Issue trackers are the main hubs for discussions and development activity, and thus the primary means of support. They includes problems, suggestions, and questions. If you are using a build for an officially-supported platform ([see the list here](docs/platforms.md)), then please refer to the [Platform-specific Support](#platform-specific-support) section to find its issue tracker. Otherwise, please use [the main issue tracker](https://github.com/ungoogled-software/ungoogled-chromium/issues). 
 * A chat room. There are two options available:
     * [Gitter](https://gitter.im/ungoogled-software/Lobby). It can use your GitHub account as an identity.
-    * Matrix.org under name `ungoogled-software/lobby`. It has a bidirectional connection with Gitter.
+    * Matrix.org at [#ungoogled-chromium:matrix.org](https://matrix.to/#/#ungoogled-chromium:matrix.org). It has a bidirectional connection with Gitter.
 
 ## Platform-specific Support
 


### PR DESCRIPTION
SUPPORT.md says the Matrix room is available "under ungoogled-software/Lobby". This is not the format of a Matrix room address, and searching for that on matrix.org does not provide any results. This PR updates SUPPORT.md to link to the actual Matrix room.