### PR TITLE
Fix search bar on new tab page for downstream disable-ai.patch users

### DIFF
--- a/patches/core/ungoogled-chromium/disable-ai.patch
+++ b/patches/core/ungoogled-chromium/disable-ai.patch
@@ -1069,15 +1069,10 @@
  #include "chrome/renderer/searchbox/searchbox_extension.h"
  #endif  // !BUILDFLAG(IS_ANDROID)
  
-@@ -336,20 +335,6 @@ void ChromeRenderFrameObserver::DidCommi
- }
+@@ -341,14 +340,6 @@ void ChromeRenderFrameObserver::DidClear
+     SearchBoxExtension::Install(render_frame()->GetWebFrame());
+   }
  
- void ChromeRenderFrameObserver::DidClearWindowObject() {
--#if !BUILDFLAG(IS_ANDROID)
--  if (process_state::IsInstantProcess()) {
--    SearchBoxExtension::Install(render_frame()->GetWebFrame());
--  }
--
 -  // Install ReadAnythingAppController on render frames with the Read Anything
 -  // url, which is chrome-untrusted. ReadAnythingAppController installs v8
 -  // bindings in the chrome.readingMode namespace which are consumed by
@@ -1086,10 +1081,9 @@
 -      chrome::kChromeUIUntrustedReadAnythingSidePanelURL) {
 -    ReadAnythingAppController::Install(render_frame());
 -  }
--#endif  // !BUILDFLAG(IS_ANDROID)
+ #endif  // !BUILDFLAG(IS_ANDROID)
  #if BUILDFLAG(ENABLE_GUEST_VIEW) && !BUILDFLAG(ENABLE_EXTENSIONS_CORE)
    guest_view::SlimWebViewBindings::MaybeInstall(*render_frame());
- #endif  // BUILDFLAG(ENABLE_GUEST_VIEW) && !BUILDFLAG(ENABLE_EXTENSIONS_CORE)
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
 @@ -2703,9 +2703,6 @@ if (!is_android) {


### PR DESCRIPTION
When debian switched to using u-c's disable-ai.patch, we found that the offline new tab page was broken. Instead, users were sent to an online search engine, which is not desirable. It turns out that the part of this patch that removed ReadAnythingAppController was also removing unrelated (to AI) SearchBoxExtension code. This puts the code back.

More details can be seen @ https://bugs.debian.org/1132651

Note that u-c users don't see this due to the new tab page being overridden by extra/inox-patchset/0008-restore-classic-ntp.patch. However, at some point if that other patch were removed, u-c would've hit the same bug.

*(Please ensure you have read SUPPORT.md and docs/contributing.md before submitting the Pull Request)*
