### PR TITLE
Pin depot_tools to commit 5e98835 in utils/clone.py

### DIFF
--- a/utils/clone.py
+++ b/utils/clone.py
@@ -88,8 +88,8 @@ def clone(args): # pylint: disable=too-many-branches, too-many-locals, too-many-
 
     get_logger().info('Cloning depot_tools')
     # To-Do: Undo this conditional once upstream rolls depot_tools
-    # More info: https://github.com/ungoogled-software/ungoogled-chromium/pull/3738#issuecomment-4256065678
-    if (chromium_version == '147.0.7727.101'):
+    # https://github.com/ungoogled-software/ungoogled-chromium/pull/3738#issuecomment-4256065678
+    if chromium_version == '147.0.7727.101':
         dt_commit = '5e9883513113f4c6b74e33d80c066075d0fd3960'
     else:
         dt_commit = re.search(r"depot_tools\.git'\s*\+\s*'@'\s*\+\s*'([^']+)',",

--- a/utils/clone.py
+++ b/utils/clone.py
@@ -87,6 +87,8 @@ def clone(args): # pylint: disable=too-many-branches, too-many-locals, too-many-
     ucstaging.mkdir(exist_ok=True)
 
     get_logger().info('Cloning depot_tools')
+    # To-Do: Undo this conditional once upstream rolls depot_tools
+    # More info: https://github.com/ungoogled-software/ungoogled-chromium/pull/3738#issuecomment-4256065678
     if (chromium_version == '147.0.7727.101'):
         dt_commit = '5e9883513113f4c6b74e33d80c066075d0fd3960'
     else:

--- a/utils/clone.py
+++ b/utils/clone.py
@@ -93,7 +93,7 @@ def clone(args): # pylint: disable=too-many-branches, too-many-locals, too-many-
         dt_commit = '5e9883513113f4c6b74e33d80c066075d0fd3960'
     else:
         dt_commit = re.search(r"depot_tools\.git'\s*\+\s*'@'\s*\+\s*'([^']+)',",
-                            Path(args.output / 'DEPS').read_text(encoding=ENCODING)).group(1)
+                              Path(args.output / 'DEPS').read_text(encoding=ENCODING)).group(1)
     if not dt_commit:
         get_logger().error('Unable to obtain commit for depot_tools checkout')
         sys.exit(1)

--- a/utils/clone.py
+++ b/utils/clone.py
@@ -87,8 +87,11 @@ def clone(args): # pylint: disable=too-many-branches, too-many-locals, too-many-
     ucstaging.mkdir(exist_ok=True)
 
     get_logger().info('Cloning depot_tools')
-    dt_commit = re.search(r"depot_tools\.git'\s*\+\s*'@'\s*\+\s*'([^']+)',",
-                          Path(args.output / 'DEPS').read_text(encoding=ENCODING)).group(1)
+    if (chromium_version == '147.0.7727.101'):
+        dt_commit = '5e9883513113f4c6b74e33d80c066075d0fd3960'
+    else:
+        dt_commit = re.search(r"depot_tools\.git'\s*\+\s*'@'\s*\+\s*'([^']+)',",
+                            Path(args.output / 'DEPS').read_text(encoding=ENCODING)).group(1)
     if not dt_commit:
         get_logger().error('Unable to obtain commit for depot_tools checkout')
         sys.exit(1)


### PR DESCRIPTION
Chromium 147.0.7727.101 broke `utils/clone.py` due to a mismatch in the `DEPS` file ([more info](https://github.com/ungoogled-software/ungoogled-chromium/pull/3738)). However some projects like [ungoogled-chromium-macos](https://github.com/ungoogled-software/ungoogled-chromium-macos/blob/a949291cb2fc05f7c30a2606b21b7e5b04383a90/retrieve_and_unpack_resource.sh#L46) depend on this functionality.

Fix the script via an ugly hack that pins depot_tools to a specific [working commit](https://chromium.googlesource.com/chromium/tools/depot_tools.git/+/5e9883513113f4c6b74e33d80c066075d0fd3960).
