### PR TITLE
Fix Windows dictionary path in first-run-page.patch

### DIFF
--- a/patches/extra/ungoogled-chromium/first-run-page.patch
+++ b/patches/extra/ungoogled-chromium/first-run-page.patch
@@ -115,7 +115,7 @@
 +    <ul>
 +     <li>Linux: <code>~/.config/chromium/Dictionaries/</code><br></li>
 +     <li>Mac: <code>~/Library/Application Support/Chromium/Dictionaries/</code><br></li>
-+     <li>Windows: <code>%LOCALAPPDATA%\Chromium\Application\Dictionaries</code><br></li>
++     <li>Windows: <code>%LOCALAPPDATA%\Chromium\Application\Dictionaries\</code><br></li>
 +    </ul>
 +    <input id="bdic" type="file" accept=".txt,text/plain" />
 +   </li>

--- a/patches/extra/ungoogled-chromium/first-run-page.patch
+++ b/patches/extra/ungoogled-chromium/first-run-page.patch
@@ -115,7 +115,7 @@
 +    <ul>
 +     <li>Linux: <code>~/.config/chromium/Dictionaries/</code><br></li>
 +     <li>Mac: <code>~/Library/Application Support/Chromium/Dictionaries/</code><br></li>
-+     <li>Windows: <code>%LOCALAPPDATA%\Chromium\User Data\Dictionaries\</code><br></li>
++     <li>Windows: <code>%LOCALAPPDATA%\Chromium\Application\Dictionaries</code><br></li>
 +    </ul>
 +    <input id="bdic" type="file" accept=".txt,text/plain" />
 +   </li>


### PR DESCRIPTION
Update the dictionary file path for Windows in the first run page to ensure consistency with the FAQ and actual application behavior.

The guidance previously pointed to:
%LOCALAPPDATA%\Chromium\User Data\Dictionaries\

It has been corrected to the functional path:
%LOCALAPPDATA%\Chromium\Application\Dictionaries\

This alignment resolves the contradiction between the first run guidance and the FAQ page (https://ungoogled-software.github.io/ungoogled-chromium-wiki/faq#how-do-i-fix-the-spell-checker), ensuring users can correctly locate or install dictionary files.

*(Please ensure you have read SUPPORT.md and docs/contributing.md before submitting the Pull Request)*
