### PR TITLE
Add patch for disabling JIT

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -25,6 +25,7 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--max-connections-per-host` | (from Bromite) Configure the maximum allowed connections per host. Valid values are `6` and `15`
   `--omnibox-autocomplete-filtering` | Restrict omnibox autocomplete results to a combination of search suggestions (if enabled), bookmarks, and internal chrome pages. Accepts `search`, `search-bookmarks`, `search-chrome`, and `search-bookmarks-chrome`.
   `--popups-to-tabs` | Makes popups open in new tabs.
+  `--disabling-javascript-optimization-disables-jit` | Disables JIT too if the "JavaScript optimization" setting is turned off
 
 - ### Available only on desktop
 

--- a/flags.gn
+++ b/flags.gn
@@ -15,3 +15,7 @@ safe_browsing_mode=0
 treat_warnings_as_errors=false
 use_official_google_api_keys=false
 use_unofficial_version_number=false
+
+# uncomment below to enable wasm support when JIT is disabled
+# v8_enable_drumbrake = true
+# v8_drumbrake_bounds_checks = true

--- a/flags.gn
+++ b/flags.gn
@@ -15,7 +15,5 @@ safe_browsing_mode=0
 treat_warnings_as_errors=false
 use_official_google_api_keys=false
 use_unofficial_version_number=false
-
-# uncomment below to enable wasm support when JIT is disabled
-# v8_enable_drumbrake = true
-# v8_drumbrake_bounds_checks = true
+v8_drumbrake_bounds_checks = true
+v8_enable_drumbrake = true

--- a/patches/extra/ungoogled-chromium/add-flag-for-disabling-jit.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-disabling-jit.patch
@@ -1,0 +1,35 @@
+--- a/content/browser/renderer_host/render_process_host_impl.cc
++++ b/content/browser/renderer_host/render_process_host_impl.cc
+@@ -3524,7 +3524,10 @@ bool RenderProcessHostImpl::IsForTopChromeWebUI() const {
+ }
+
+ bool RenderProcessHostImpl::IsJitDisabled() {
+-  return !!(flags_ & RenderProcessFlags::kJitDisabled);
++  return !!(flags_ & RenderProcessFlags::kJitDisabled) ||
++         (base::CommandLine::ForCurrentProcess()->HasSwitch(
++              "disabling-javascript-optimization-disables-jit") &&
++          RenderProcessHostImpl::AreV8OptimizationsDisabled());
+ }
+
+ bool RenderProcessHostImpl::AreV8OptimizationsDisabled() {
+@@ -3652,6 +3655,9 @@ void RenderProcessHostImpl::AppendRendererCommandLine(
+   if (IsJitDisabled()) {
+     AppendToCommaSeparatedSwitch(
+         command_line, blink::switches::kJavaScriptFlags, "--jitless");
++
++    AppendToCommaSeparatedSwitch(
++        command_line, blink::switches::kJavaScriptFlags, "--wasm_jitless");
+   } else if (AreV8OptimizationsDisabled()) {
+     AppendToCommaSeparatedSwitch(command_line,
+                                  blink::switches::kJavaScriptFlags,
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -140,4 +140,8 @@
+      "Increases the storage quota for Incognito and Guest profiles",
+      "Makes Incognito and Guest profiles compute the storage quota with the same algorithm that regular profiles use. This makes it harder for websites to detect Incognito mode, but may allow sites to induce heavy memory pressure. ungoogled-chromium flag.",
+      kOsAll, FEATURE_VALUE_TYPE(storage::features::kIncreaseIncognitoStorageQuota)},
++    {"disabling-javascript-optimization-disables-jit",
++     "Disabling JavaScript optimization disables JIT",
++     "If enabled, disables JIT too if the \"JavaScript optimization\" setting is turned off. ungoogled-chromium flag.",
++     kOsAll, SINGLE_VALUE_TYPE("disabling-javascript-optimization-disables-jit")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/series
+++ b/patches/series
@@ -107,3 +107,4 @@ extra/ungoogled-chromium/add-credits.patch
 extra/ungoogled-chromium/disable-ai-search-shortcuts.patch
 extra/ungoogled-chromium/disable-fedcm-by-default.patch
 extra/ungoogled-chromium/bundle-hyphenation-patterns.patch
+extra/ungoogled-chromium/add-flag-for-disabling-jit.patch


### PR DESCRIPTION
This PR adds a flag to disable JIT using the existing "JavaScript optimization" setting. If the flag is enabled, turning off JavaScript optimization also turns off JIT. Normally turning off JIT disables webasm as well, which breaks some sites, but Microsoft's drumbrake allows it to still work even with JIT turned off. That's not enabled by default, so that also requires adding the following flags to flags.gn:
```
v8_enable_drumbrake = true
v8_drumbrake_bounds_checks = true
```
~I wanted to keep the changes small, so I left the flags commented out by default. The code always adds the `--wasm_jitless` flag regardless of whether drumbrake is enabled, but it doesn't seem to cause ill effects even if drumbrake is disabled, so I didn't adding a guard for it.~

Other Chromium based browsers have this feature, though with slightly nicer UI:

https://github.com/brave/brave-core/pull/30703/files

https://github.com/GrapheneOS/Vanadium/

To test, go to https://ffmpegwasm.netlify.app/playground/
1. If it's stuck on loading, then webasm is disabled. You can also check for a console message for "ReferenceError: WebAssembly is not defined"
2. To test whether drumbrake is enabled, try encoding a video file. Click "load sample files", then paste the following into the arguments box: `["-i", "video.webm", "-c:v", "libx264", "video.mp4"]`. With JIT enabled the file encodes in around 7s, but with JIT disabled and with drumbrake, it takes over 2 minutes.