### PR TITLE
extra/disable-jit-flag: build drumbrake only if supported

### DIFF
--- a/flags.gn
+++ b/flags.gn
@@ -16,4 +16,3 @@ treat_warnings_as_errors=false
 use_official_google_api_keys=false
 use_unofficial_version_number=false
 v8_drumbrake_bounds_checks=true
-v8_enable_drumbrake=true

--- a/patches/extra/ungoogled-chromium/add-flag-for-disabling-jit.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-disabling-jit.patch
@@ -9,6 +9,30 @@
 +     "If enabled, disables JIT too if the \"JavaScript optimization\" setting is turned off. ungoogled-chromium flag.",
 +     kOsAll, SINGLE_VALUE_TYPE("disabling-javascript-optimization-disables-jit")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
+--- a/v8/gni/v8.gni
++++ b/v8/gni/v8.gni
+@@ -102,9 +102,6 @@ declare_args() {
+   # Sets -DV8_LITE_MODE.
+   v8_enable_lite_mode = false
+ 
+-  # WebAssembly interpreter (DrumBrake)  build flag.
+-  v8_enable_drumbrake = false
+-
+   # Enable Wasm interpreter tracing.
+   v8_enable_drumbrake_tracing = false
+ 
+@@ -351,6 +348,11 @@ is_drumbrake_supported =
+     (target_os == "win" || target_os == "linux" || target_os == "mac" ||
+      target_os == "ios")
+ 
++declare_args() {
++  # WebAssembly interpreter (DrumBrake)  build flag.
++  v8_enable_drumbrake = is_drumbrake_supported
++}
++
+ # Turbofan is enabled by default, except in lite mode.
+ if (v8_enable_turbofan == "") {
+   v8_enable_turbofan = !v8_enable_lite_mode
 --- a/content/browser/renderer_host/render_process_host_impl.cc
 +++ b/content/browser/renderer_host/render_process_host_impl.cc
 @@ -3614,7 +3614,10 @@ bool RenderProcessHostImpl::ShouldSendGp


### PR DESCRIPTION
Moves the `v8_enable_drumbrake` arg below `is_drumbrake_supported`, so that we can use it as the deciding factor on whether it should be built.

Resolves #3792
