### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/devutils/check_downloads_ini.py
+++ b/devutils/check_downloads_ini.py
@@ -31,7 +31,7 @@ def check_downloads_ini(downloads_ini_iter):
 
     downloads_ini_iter must be an iterable of strings to downloads.ini files.
 
-    Returns True if errors occured, False otherwise.
+    Returns True if errors occurred, False otherwise.
     """
     try:
         DownloadInfo(downloads_ini_iter)

--- a/devutils/check_patch_files.py
+++ b/devutils/check_patch_files.py
@@ -52,7 +52,7 @@ def check_patch_readability(patches_dir, series_path=Path('series')):
     Check if the patches from iterable patch_path_iter are readable.
         Patches that are not are logged to stdout.
 
-    Returns True if warnings occured, False otherwise.
+    Returns True if warnings occurred, False otherwise.
     """
     warnings = False
     for patch_path in _read_series_file(patches_dir, series_path, join_dir=True):

--- a/devutils/validate_patches.py
+++ b/devutils/validate_patches.py
@@ -39,7 +39,7 @@ try:
     import urllib3.util
 
     class _VerboseRetry(urllib3.util.Retry):
-        """A more verbose version of HTTP Adatper about retries"""
+        """A more verbose version of HTTP Adapter about retries"""
 
         def sleep_for_retry(self, response=None):
             """Sleeps for Retry-After, and logs the sleep time"""

--- a/utils/clone.py
+++ b/utils/clone.py
@@ -110,7 +110,7 @@ def clone(args): # pylint: disable=too-many-branches, too-many-locals, too-many-
         check=True,
         universal_newlines=True)
 
-    # Manualy set up the gsutil directory for newer versions of Python
+    # Manually set up the gsutil directory for newer versions of Python
     get_logger().info('Cloning gsutil')
     if not gsupath.exists():
         gsupath.mkdir(parents=True)
@@ -226,7 +226,7 @@ def clone(args): # pylint: disable=too-many-branches, too-many-locals, too-many-
     move(str(gnpath / 'out' / 'last_commit_position.h'),
          str(args.output / 'tools' / 'gn' / 'bootstrap'))
 
-    get_logger().info('Removing uneeded files')
+    get_logger().info('Removing unneeded files')
     for path in sorted(args.output.rglob('*'), key=lambda l: len(str(l)), reverse=True):
         if not path.is_symlink() and '.git' not in path.parts:
             if path.is_file() and (('out' in path.parts and 'node_modules' not in path.parts)

--- a/utils/domain_substitution.py
+++ b/utils/domain_substitution.py
@@ -219,7 +219,7 @@ def apply_substitution(regex_path, files_path, source_tree, domainsub_cache):
                                  f'the file index hash delimiter "{_INDEX_HASH_DELIMITER}"')
             path = resolved_tree / relative_path
             if not path.exists():
-                get_logger().warning('Skipping non-existant path: %s', path)
+                get_logger().warning('Skipping non-existent path: %s', path)
                 continue
             if path.is_symlink():
                 get_logger().warning('Skipping path that has become a symlink: %s', path)

--- a/utils/tests/test_patches.py
+++ b/utils/tests/test_patches.py
@@ -20,7 +20,7 @@ def test_find_and_check_patch():
         patches.find_and_check_patch(patch_bin_path=Path('/this/should/not/exist'))
 
     with pytest.raises(RuntimeError):
-        # Use comamnd "false" to return non-zero exit code
+        # Use command "false" to return non-zero exit code
         patches.find_and_check_patch(patch_bin_path=Path('/bin/false'))
 
 


### PR DESCRIPTION
Fixes a handful of typos found with codespell in `utils/` and `devutils/` comments, docstrings, and log messages:

- `check_downloads_ini.py`, `check_patch_files.py`: "occured" -> "occurred"
- `validate_patches.py`: "Adatper" -> "Adapter"
- `clone.py`: "Manualy" -> "Manually", "uneeded" -> "unneeded"
- `domain_substitution.py`: "non-existant" -> "non-existent"
- `tests/test_patches.py`: "comamnd" -> "command"

Comments and strings only, no behavior change. yapf (0.32.0, the pinned version) is clean on the changed files and codespell reports no remaining issues in these directories.