### PR TITLE
Fix building with ASAN+UBSAN

### DIFF
--- a/patches/core/ungoogled-chromium/disable-ai.patch
+++ b/patches/core/ungoogled-chromium/disable-ai.patch
@@ -861,6 +861,32 @@
  
    // Holds subscriptions for TabInterface callbacks.
    std::vector<base::CallbackListSubscription> tab_subscriptions_;
+--- a/chrome/browser/ui/tabs/public/tab_features.h
++++ b/chrome/browser/ui/tabs/public/tab_features.h
+@@ -121,12 +121,6 @@ namespace permissions {
+ class PermissionIndicatorsTabData;
+ }  // namespace permissions
+ 
+-#if !BUILDFLAG(IS_ANDROID)
+-namespace skills {
+-class SkillsUpdateObserver;
+-}  // namespace skills
+-#endif  // !BUILDFLAG(IS_ANDROID)
+-
+ namespace sync_sessions {
+ class SyncSessionsRouterTabHelper;
+ }  // namespace sync_sessions
+@@ -570,10 +564,6 @@ class TabFeatures {
+   std::unique_ptr<contextual_tasks::ContextualTasksTabVisitTracker>
+       contextual_tasks_tab_visit_tracker_;
+ 
+-#if !BUILDFLAG(IS_ANDROID)
+-  std::unique_ptr<skills::SkillsUpdateObserver> skills_update_observer_;
+-#endif  //  !BUILDFLAG(IS_ANDROID)
+-
+ #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_WIN)
+   std::unique_ptr<enterprise_reporting::SaasUsageNavigationObserver>
+       saas_usage_navigation_observer_;
 --- a/chrome/browser/ui/tabs/tab_features.cc
 +++ b/chrome/browser/ui/tabs/tab_features.cc
 @@ -395,11 +395,6 @@ void TabFeatures::Init(TabInterface& tab

--- a/patches/extra/ungoogled-chromium/fix-building-without-mdns-and-service-discovery.patch
+++ b/patches/extra/ungoogled-chromium/fix-building-without-mdns-and-service-discovery.patch
@@ -52,3 +52,85 @@
  }
  
  void DnsSdDeviceLister::OnPermissionRejected() {
+--- a/chrome/browser/media/router/discovery/mdns/dns_sd_registry.cc
++++ b/chrome/browser/media/router/discovery/mdns/dns_sd_registry.cc
+@@ -97,11 +97,6 @@ DnsSdRegistry::DnsSdRegistry() {
+ #endif
+ }
+ 
+-DnsSdRegistry::DnsSdRegistry(
+-    local_discovery::ServiceDiscoverySharedClient* client) {
+-  service_discovery_client_ = client;
+-}
+-
+ DnsSdRegistry::~DnsSdRegistry() {
+   DCHECK(thread_checker_.CalledOnValidThread());
+ }
+@@ -124,9 +119,8 @@ void DnsSdRegistry::RemoveObserver(DnsSd
+ 
+ DnsSdDeviceLister* DnsSdRegistry::CreateDnsSdDeviceLister(
+     DnsSdDelegate* delegate,
+-    const std::string& service_type,
+-    local_discovery::ServiceDiscoverySharedClient* discovery_client) {
+-  return new DnsSdDeviceLister(discovery_client, delegate, service_type);
++    const std::string& service_type) {
++  return new DnsSdDeviceLister(nullptr, delegate, service_type);
+ }
+ 
+ void DnsSdRegistry::Publish(const std::string& service_type) {
+@@ -154,8 +148,7 @@ void DnsSdRegistry::RegisterDnsSdListene
+   }
+ 
+   std::unique_ptr<DnsSdDeviceLister> dns_sd_device_lister(
+-      CreateDnsSdDeviceLister(this, service_type,
+-                              service_discovery_client_.get()));
++      CreateDnsSdDeviceLister(this, service_type));
+   dns_sd_device_lister->Discover();
+   service_data_map_[service_type] =
+       std::make_unique<ServiceTypeData>(std::move(dns_sd_device_lister));
+@@ -176,7 +169,6 @@ void DnsSdRegistry::UnregisterDnsSdListe
+ 
+ void DnsSdRegistry::ResetForTest() {
+   service_data_map_.clear();
+-  service_discovery_client_.reset();
+ }
+ 
+ void DnsSdRegistry::ServiceChanged(const std::string& service_type,
+--- a/chrome/browser/media/router/discovery/mdns/dns_sd_registry.h
++++ b/chrome/browser/media/router/discovery/mdns/dns_sd_registry.h
+@@ -16,10 +16,6 @@
+ #include "base/threading/thread_checker.h"
+ #include "chrome/browser/media/router/discovery/mdns/dns_sd_delegate.h"
+ 
+-namespace local_discovery {
+-class ServiceDiscoverySharedClient;
+-}
+-
+ namespace media_router {
+ 
+ class DnsSdDeviceLister;
+@@ -103,8 +99,7 @@ class DnsSdRegistry : public DnsSdDelega
+ 
+   virtual DnsSdDeviceLister* CreateDnsSdDeviceLister(
+       DnsSdDelegate* delegate,
+-      const std::string& service_type,
+-      local_discovery::ServiceDiscoverySharedClient* discovery_client);
++      const std::string& service_type);
+ 
+   // DnsSdDelegate implementation:
+   void ServiceChanged(const std::string& service_type,
+@@ -123,14 +118,11 @@ class DnsSdRegistry : public DnsSdDelega
+   friend class TestDnsSdRegistry;
+ 
+   DnsSdRegistry();
+-  explicit DnsSdRegistry(local_discovery::ServiceDiscoverySharedClient* client);
+   virtual ~DnsSdRegistry();
+ 
+   void DispatchApiEvent(const std::string& service_type);
+   bool IsRegistered(const std::string& service_type);
+ 
+-  scoped_refptr<local_discovery::ServiceDiscoverySharedClient>
+-      service_discovery_client_;
+   base::ObserverList<DnsSdObserver>::Unchecked observers_;
+   base::ThreadChecker thread_checker_;
+ };


### PR DESCRIPTION
These partially defined classes cause errors such as `undefined symbol: typeinfo for local_discovery::ServiceDiscoverySharedClient` when linking in an `is_asan=true` + `is_ubsan=true` build. I believe that's due to the implementations for these not getting compiled at all, not just because of the forward-declarations.

The constructor that I deleted for `DnsSdRegistry` seems to only be used in tests so this builds fine without it.