### PR TITLE
Fix safe_browsing in v8 setting

### DIFF
--- a/patches/core/ungoogled-chromium/move-js-optimizer-unfamiliar-sites.patch
+++ b/patches/core/ungoogled-chromium/move-js-optimizer-unfamiliar-sites.patch
@@ -11,6 +11,29 @@
  
  using extensions::api::settings_private::Enforcement;
  using extensions::api::settings_private::PrefObject;
+--- a/chrome/browser/resources/settings/site_settings/v8_page.ts
++++ b/chrome/browser/resources/settings/site_settings/v8_page.ts
+@@ -13,7 +13,6 @@ import {PrefsMixin} from '/shared/settin
+ import {I18nMixin} from 'chrome://resources/cr_elements/i18n_mixin.js';
+ import {PolymerElement} from 'chrome://resources/polymer/v3_0/polymer/polymer_bundled.min.js';
+ 
+-import {SafeBrowsingSetting} from '../privacy_page/security/safe_browsing_types.js';
+ import {SettingsViewMixin} from '../settings_page/settings_view_mixin.js';
+ 
+ import {ContentSettingsTypes, JavascriptOptimizerSetting} from './constants.js';
+@@ -56,11 +55,8 @@ export class V8PageElement extends V8Pag
+   }
+ 
+   private getBlockForUnfamiliarSitesSubLabel_(): string {
+-    const safeBrowsingSetting = this.getPref('generated.safe_browsing').value;
+     return this.i18n(
+-        safeBrowsingSetting === SafeBrowsingSetting.DISABLED
+-            ? 'siteSettingsJavascriptOptimizerBlockedUnfamiliarSitesSafeBrowsingOffSubLabel'
+-            : 'siteSettingsJavascriptOptimizerBlockedUnfamiliarSitesSubLabel');
++        'siteSettingsJavascriptOptimizerBlockedUnfamiliarSitesSubLabel');
+   }
+ }
+ 
 --- a/chrome/browser/site_protection/site_familiarity_utils.cc
 +++ b/chrome/browser/site_protection/site_familiarity_utils.cc
 @@ -9,6 +9,7 @@


### PR DESCRIPTION
Opening `chrome://settings/content/v8` can throw the following error:

```
shared.rollup.js:5 Uncaught Error: Assertion failed: Pref is missing: generated.safe_browsing
    at assert (shared.rollup.js:5:55)
    at HTMLElement.getPref (shared.rollup.js:1022:205)
    at HTMLElement.getBlockForUnfamiliarSitesSubLabel_ (lazy_load.js:6474:593)
    at Me (polymer_bundled.min.js:1:30916)
    at V8PageElement._evaluateBinding (polymer_bundled.min.js:1:43690)
    at Object.Se [as fn] (polymer_bundled.min.js:1:29165)
    at me (polymer_bundled.min.js:1:25418)
    at s (polymer_bundled.min.js:1:37027)
    at HTMLElement._runEffectsForTemplate (polymer_bundled.min.js:1:37183)
    at HTMLElement._propagatePropertyChanges (polymer_bundled.min.js:1:36929)
assert @ shared.rollup.js:5
getPref @ shared.rollup.js:1022
getBlockForUnfamiliarSitesSubLabel_ @ lazy_load.js:6474
Me @ polymer_bundled.min.js:1
_evaluateBinding @ polymer_bundled.min.js:1
Se @ polymer_bundled.min.js:1
me @ polymer_bundled.min.js:1
s @ polymer_bundled.min.js:1
_runEffectsForTemplate @ polymer_bundled.min.js:1
_propagatePropertyChanges @ polymer_bundled.min.js:1
```

This PR removes the `getPref('generated.safe_browsing')` call. 

Fixes https://github.com/ungoogled-software/ungoogled-chromium-windows/issues/608