### PR TITLE
Ensure that when patch is used by itself, NOTREACHED() isn't reached

### DIFF
--- a/patches/core/ungoogled-chromium/remove-navigation-source-param.patch
+++ b/patches/core/ungoogled-chromium/remove-navigation-source-param.patch
@@ -2,11 +2,10 @@
 # when navigating from the onmibox/realbox
 --- a/components/search_engines/template_url.cc
 +++ b/components/search_engines/template_url.cc
-@@ -1413,26 +1413,6 @@ std::string TemplateURLRef::HandleReplac
-         // url.insert(replacement.index, used_www ? "gcx=w&" : "gcx=c&");
+@@ -1414,23 +1414,6 @@ std::string TemplateURLRef::HandleReplac
          break;
  
--      case GOOGLE_SEARCH_SOURCE: {
+       case GOOGLE_SEARCH_SOURCE: {
 -        DCHECK(!replacement.is_post_param);
 -        using OEP = ::metrics::OmniboxEventProto;
 -        std::string source_param;
@@ -24,8 +23,6 @@
 -        if (!source_param.empty()) {
 -          HandleReplacement("source", source_param, replacement, &url);
 -        }
--        break;
--      }
+         break;
+       }
  
-       case GOOGLE_SEARCH_SOURCE_ID: {
-         DCHECK(!replacement.is_post_param);


### PR DESCRIPTION
Debian is cherry-picking the remove-navigation-source-param.patch patch, and the recent update to v150 saw a crash on startup that "plmaneo" <plmaneo@agent.qq.com> tracked back to the patch:

https://bugs.debian.org/1141488

Because we're not including
patches/core/ungoogled-chromium/replace-google-search-engine-with-nosearch.patch, we still have the {google:searchSource} token in use. The navigation source param patch is entirely removing the GOOGLE_SEARCH_SOURCE case in the switch statement, so we end up hitting the default case and triggering NOTREACHED() and crashing.

This is easy to fix, simply leaving the GOOGLE_SEARCH_SOURCE case there as a no-op. This shouldn't affect ungoogled-chromium functionality, but would fix things for downstream users of this patch by keeping it a standalone patch with no further dependencies on other patches.

The original fix is by plmaneo <plmaneo@agent.qq.com>, though I also dropped the DCHECK() because we don't actually need it.

*(Please ensure you have read SUPPORT.md and docs/contributing.md before submitting the Pull Request)*
