### PR TITLE
optimize disable_ai_patch,remove unnecessary code.

### DIFF
--- a/patches/core/ungoogled-chromium/disable-ai.patch
+++ b/patches/core/ungoogled-chromium/disable-ai.patch
@@ -135,17 +135,7 @@
 -
    return nullptr;
  }
- 
---- a/chrome/browser/actor/ui/actor_ui_tab_controller.cc
-+++ b/chrome/browser/actor/ui/actor_ui_tab_controller.cc
-@@ -50,7 +50,6 @@ ActorUiTabController::ActorUiTabControll
-       scoped_unowned_user_data_(tab.GetUnownedUserDataHost(), *this) {
-   CHECK(base::FeatureList::IsEnabled(features::kGlicActorUi));
-   CHECK(base::FeatureList::IsEnabled(features::kGlicActor));
--  CHECK(actor_keyed_service_);
- }
- 
- ActorUiTabController::~ActorUiTabController() = default;
+
 --- a/chrome/browser/browser_process_impl.cc
 +++ b/chrome/browser/browser_process_impl.cc
 @@ -260,12 +260,10 @@ void OnLocalStatePrefsLoaded();


### PR DESCRIPTION
This value is now always guaranteed to be present, so it can never be null. We can remove this check. Otherwise, keeping it here is a bit inconsistent, since the other usages of this value in this file don't perform any null checks. It makes the code look a little odd.
