### PR TITLE
Fix global variables in Python 3.14 multiprocessing processes

### DIFF
--- a/devutils/update_lists.py
+++ b/devutils/update_lists.py
@@ -12,11 +12,11 @@ the process has finished.
 """
 
 import argparse
+import multiprocessing
 import os
 import sys
 
 from itertools import repeat
-from multiprocessing import Pool
 from pathlib import Path, PurePosixPath
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'utils'))
@@ -315,7 +315,7 @@ def compute_lists(source_tree, search_regex, processes): # pylint: disable=too-m
     unused_patterns = UnusedPatterns()
 
     # Launch multiple processes iterating over the source tree
-    with Pool(processes) as procpool:
+    with multiprocessing.Pool(processes) as procpool:
         returned_data = procpool.starmap(
             compute_lists_proc,
             zip(source_tree.rglob('*'), repeat(source_tree), repeat(search_regex)))
@@ -404,4 +404,5 @@ def main(args_list=None):
 
 
 if __name__ == "__main__":
+    multiprocessing.set_start_method('fork')
     main()


### PR DESCRIPTION
This addresses an issue in the `update_lists.py` script that I found almost by accident.

The immediate problem was that although I was passing in e.g. `--domain-exclude-prefix .pc/` so that it would ignore the files under `.pc/` for domain-substitution purposes, the resulting list erroneously included files under that prefix. And this occurred only on Ubuntu 26.04, whereas 24.04 excluded those files as intended.

Specifically, even though `.pc/` was added to the `DOMAIN_EXCLUDE_PREFIXES` list when the program's arguments were parsed, by the time the program got to the point of use in `compute_lists_proc()`, that entry was missing. The list was back to the original/default value assigned at the top of the program.

I dug into this, and eventually tracked the problem down to a recent change (Python 3.14) in the behavior of the `multiprocessing` module, specifically having to do with [start methods](https://docs.python.org/3/library/multiprocessing.html#multiprocessing-start-methods).

In Ubuntu 24.04 (Python 3.12), the default start method was "fork". In 26.04, it is now "forkserver". The Python docs make the following [note](https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods) relating to "forkserver":

> Global variables
>
> Bear in mind that if code run in a child process tries to access a global variable, then the value it sees (if any) may not be the same as the value in the parent process at the time that Process.start was called.

So with "forkserver", it appears that the way in which newly-created processes inherit the parent's global variables is not compatible with us modifying those global variables (as occurs when you pass in e.g. `--domain-exclude-prefix`).

This minimal-ish fix, then, updates the code to explicitly use the "fork" method, and I've confirmed that this yields the expected results when running on Ubuntu 26.04.