### PR TITLE
devutils/update_lists: use fork multiprocessing only on posix

### DIFF
--- a/devutils/update_lists.py
+++ b/devutils/update_lists.py
@@ -404,5 +404,6 @@ def main(args_list=None):
 
 
 if __name__ == "__main__":
-    multiprocessing.set_start_method('fork')
+    if os.name == 'posix':
+        multiprocessing.set_start_method('fork')
     main()


### PR DESCRIPTION
fixes breakage on windows introduced by #3866.

fork is indeed available on all POSIX systems, but windows isn't one, so we use the default spawn method on all non-POSIX systems (nt/windows) instead.