### PR TITLE
Fix incidental build breakage from block-requests.patch

### DIFF
--- a/patches/core/ungoogled-chromium/block-requests.patch
+++ b/patches/core/ungoogled-chromium/block-requests.patch
@@ -122,14 +122,10 @@
  
  /**
   * Lazily loads the vscode.web-custom-data/browser.css-data.json and allows
-@@ -15,33 +14,14 @@ import * as Root from '../../core/root/r
- export class WebCustomData {
-   #data = new Map<string, CSSProperty>();
+@@ -19,18 +18,7 @@ export class WebCustomData {
+   readonly fetchPromiseForTest: Promise<unknown>;
  
--  /** The test actually needs to wait for the result */
--  readonly fetchPromiseForTest: Promise<unknown>;
--
--  constructor(remoteBase: string) {
+   constructor(remoteBase: string) {
 -    if (!remoteBase) {
 -      this.fetchPromiseForTest = Promise.resolve();
 -      return;
@@ -142,22 +138,22 @@
 -                                     }
 -                                   })
 -                                   .catch();
--  }
--
++    this.fetchPromiseForTest = Promise.resolve();
+   }
+ 
    /**
-    * Creates a fresh `WebCustomData` instance using the standard
-    * DevTools remote base.
+@@ -39,9 +27,8 @@ export class WebCustomData {
     * Throws if no valid remoteBase was found.
     */
    static create(): WebCustomData {
 -    const remoteBase = Root.Runtime.getRemoteBase();
      // Silently skip loading of the CSS data if remoteBase is not set properly.
 -    return new WebCustomData(remoteBase?.base ?? '');
-+    return new WebCustomData();
++    return new WebCustomData('');
    }
  
    /**
-@@ -54,9 +34,6 @@ export class WebCustomData {
+@@ -54,9 +41,6 @@ export class WebCustomData {
    }
  }
  


### PR DESCRIPTION
This is not intended to change any run-time behavior, but to fix the build of an incidental test-related target. I encountered this in the course of bringing [Debian support for pre-generated source code](https://salsa.debian.org/chromium-team/chromium/-/merge_requests/42) to the ungoogled-chromium conversion of the Debian chromium package:
```
$ ninja -C out/Release gen/third_party/devtools-frontend/src/front_end/panels/elements/unittests-tsconfig.json
[...]
FAILED: [code=1] gen/third_party/devtools-frontend/src/front_end/panels/elements/unittests-tsconfig.json [...]

TypeScript compilation failed. Used tsconfig gen/third_party/devtools-frontend/src/front_end/panels/elements/unittests-tsconfig.json

third_party/devtools-frontend/src/front_end/panels/elements/WebCustomData.test.ts(34,70): error TS2554: Expected 0 arguments, but got 1.
third_party/devtools-frontend/src/front_end/panels/elements/WebCustomData.test.ts(40,27): error TS2339: Property 'fetchPromiseForTest' does not exist on type 'WebCustomData'.
third_party/devtools-frontend/src/front_end/panels/elements/WebCustomData.test.ts(50,70): error TS2554: Expected 0 arguments, but got 1.
third_party/devtools-frontend/src/front_end/panels/elements/WebCustomData.test.ts(56,70): error TS2554: Expected 0 arguments, but got 1.
third_party/devtools-frontend/src/front_end/panels/elements/WebCustomData.test.ts(59,29): error TS2339: Property 'fetchPromiseForTest' does not exist on type 'WebCustomData'.
third_party/devtools-frontend/src/front_end/panels/elements/WebCustomData.test.ts(68,70): error TS2554: Expected 0 arguments, but got 1.
third_party/devtools-frontend/src/front_end/panels/elements/WebCustomData.test.ts(75,27): error TS2339: Property 'fetchPromiseForTest' does not exist on type 'WebCustomData'.

ninja: build stopped: subcommand failed.
```

The nature of the pre-gen framework is that all files produced by certain scripts [which need recent versions of things like Node.js to run] are generated for later use, and avoiding the need to exclude certain files simplifies the process.